### PR TITLE
WIP Add eclfio_array_get/put

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -187,7 +187,7 @@ target_compile_definitions(ecl PRIVATE
             -DECL_VERSION_MAJOR=${ECL_VERSION_MAJOR}
             -DECL_VERSION_MINOR=${ECL_VERSION_MINOR}
             -DECL_VERSION_MICRO=${ECL_VERSION_MICRO}
-            $<$<BOOL:${BIG_ENDIAN}>:HOST_BIG_ENDIAN>
+            $<${BIG_ENDIAN}:HOST_BIG_ENDIAN>
 )
 
 target_compile_options(ecl PUBLIC ${pthreadarg})

--- a/lib/e3/ecl/fortio.h
+++ b/lib/e3/ecl/fortio.h
@@ -174,6 +174,9 @@ enum ecl_errno {
     ECL_ERR_WRITE,
     ECL_INVALID_RECORD,
     ECL_EINVAL,
+    ECL_INCONSISTENT_STATE,
+    ECL_EOF,
+    ECL_UNEXPECTED_EOF,
 };
 
 #ifdef __cplusplus

--- a/lib/e3/ecl/fortio.h
+++ b/lib/e3/ecl/fortio.h
@@ -290,12 +290,11 @@ int ecl_default_blocksize( int size, int type );
  * cases, this is a Fortran block with only head and tail.
  *
  * array_get returns:
- * ECL_EINVAL           if nmemb is negative or if an inner block is not of
- *                      blocksize
- * ECL_TRUNCATED        If an inner block was not filled with elements (e.g.
+ * ECL_TRUNCATED        if an inner block was not filled with elements (e.g.
  *                      was of size 10 bytes, but the data type is int (4 bytes
  *                      each)
- * ECL_UNALIGNED_ARRAY  the last block was too large, i.e. elems > nmemb
+ * ECL_UNALIGNED_ARRAY  if an inner block was not blocksize, or the array does
+ *                      not was did not exactly represent nmemb elements
  *
  * Also returns anything returned by eclfio_get, if a read fails.
  *

--- a/lib/e3/ecl/fortio.h
+++ b/lib/e3/ecl/fortio.h
@@ -39,12 +39,14 @@ extern "C" {
  * parameters are not modified, as if the function was never called.
  *
  * This comes with a few exceptions:
- * 1. if ECL_ERR_SEEK is returned, the roll-back of the file pointer itself
- *    failed and NOTHING IS GUARANTEED. The file stream is left in an unspecified
- *    state, and must be recovered accordingly.
+ * 1. if ECL_INCONSISTENT_STATE is returned, the roll-back of the file pointer
+ *    itself failed and NOTHING IS GUARANTEED. The file stream is left in an
+ *    unspecified state, and must be recovered accordingly.
  * 2. in eclfio_get, the output record buffer must always be considered dirty
  *    and incomplete unless the function suceeds, or ECL_EINVAL is returned.
  *
+ * ECL_INCONSISTENT_STATE should be rather rare, but to provide strong
+ * guarantees, this error must be handled carefully.
  *
  * ECL_ERR_SEEK should be rather rare, but to provide strong guarantees, this
  * error must be handled carefully.

--- a/lib/e3/ecl/fortio.h
+++ b/lib/e3/ecl/fortio.h
@@ -64,9 +64,13 @@ extern "C" {
  * -------
  *  record data types:
  *      c - characters, sizeof(char)
+ *      b - byte, alias for c
+ *      s - string of fixed length 8
  *      i - (signed)integers, sizeof(int32_t), default
  *      f - single-precision float, sizeof(float)
  *      d - double-precision float, sizeof(double)
+ *
+ *  if 's' is used, transform is disabled, even when explicitly requested
  *
  * behaviour:
  *      E - assume big-endian record data (default)

--- a/lib/ecl/ecl_kw.cpp
+++ b/lib/ecl/ecl_kw.cpp
@@ -1583,23 +1583,23 @@ void ecl_kw_fskip(fortio_type *fortio) {
 
 
 static void ecl_kw_fwrite_data_unformatted( const ecl_kw_type * ecl_kw , fortio_type * fortio ) {
-  char * iobuffer = ecl_kw_alloc_output_buffer(ecl_kw);
-  int sizeof_iotype = ecl_type_get_sizeof_iotype(ecl_kw->data_type);
+    if( ecl_kw->size <= 0 ) return;
+    char * iobuffer = ecl_kw_alloc_output_buffer(ecl_kw);
+    int sizeof_iotype = ecl_type_get_sizeof_iotype(ecl_kw->data_type);
 
-  int err = eclfio_array_put( fortio_get_FILE( fortio ),
-                              "b",
-                              sizeof_iotype,
-                              ecl_kw->size,
-                              ecl_default_blocksize(
-                                      ecl_type_is_alpha( ecl_kw->data_type )
-                                        ? ECL_BLOCKSIZE_STRING
-                                        : ECL_BLOCKSIZE_NUMERIC,
-                                      0
-                                  ),
-                              iobuffer );
-
-  if( err ) util_abort("%s: write failed: %s\n",__func__ , strerror(errno));
-  free(iobuffer);
+    int err = eclfio_array_put( fortio_get_FILE( fortio ),
+                                "b",
+                                sizeof_iotype,
+                                ecl_kw->size,
+                                ecl_default_blocksize(
+                                        ecl_type_is_alpha( ecl_kw->data_type )
+                                            ? ECL_BLOCKSIZE_STRING
+                                            : ECL_BLOCKSIZE_NUMERIC,
+                                        0
+                                    ),
+                                iobuffer );
+    if( err ) util_abort("%s: write failed: %s\n",__func__ , strerror(errno));
+    free(iobuffer);
 }
 
 

--- a/lib/ecl/fortio.c
+++ b/lib/ecl/fortio.c
@@ -107,7 +107,7 @@ static fortio_type * fortio_alloc__(const char *filename , bool fmt_file , bool 
   fortio->stream_owner       = stream_owner;
   fortio->writable           = writable;
   fortio->read_size = 0;
-  strcpy( fortio->opts, endian_flip_header ? "c" : "ce" );
+  strcpy( fortio->opts, endian_flip_header ? "b" : "be" );
 
   return fortio;
 }
@@ -119,7 +119,7 @@ static fortio_type * fortio_alloc__(const char *filename , bool fmt_file , bool 
 */
 
 static bool __read_int(FILE * stream , int * value, bool endian_flip) {
-    int ok = eclfio_sizeof( stream, endian_flip ? "c" : "ce", value );
+    int ok = eclfio_sizeof( stream, endian_flip ? "b" : "be", value );
     fseek( stream, sizeof( int32_t ), SEEK_CUR );
     return !ok;
 }

--- a/lib/src/fortio.cpp
+++ b/lib/src/fortio.cpp
@@ -208,8 +208,14 @@ int eclfio_sizeof( std::FILE* fp, const char* opts, int32_t* out ) try {
     fguard guard( fp );
 
     std::int32_t size;
-    const auto read = std::fread( &size, sizeof( size ), 1, fp );
-    if( read != 1 ) return ECL_ERR_READ;
+    const auto read = std::fread( &size, 1, sizeof( size ), fp );
+    if( read == 0 and std::feof( fp ) ) return ECL_EOF;
+
+    if( read != sizeof( size ) ) {
+             if( std::feof( fp ) )   return ECL_UNEXPECTED_EOF;
+        else if( std::ferror( fp ) ) return ECL_ERR_READ;
+        else                         return ECL_ERR_UNKNOWN;
+    }
 
     if( o.bigendian )
         to_host( &size, sizeof( size ), 1 );
@@ -252,8 +258,14 @@ int eclfio_get( std::FILE* fp,
     fguard guard( fp );
 
     std::int32_t head;
-    auto read = std::fread( &head, sizeof( head ), 1, fp );
-    if( read != 1 ) return ECL_ERR_READ;
+    auto read = std::fread( &head, 1, sizeof( head ), fp );
+
+    if( read == 0 and std::feof( fp ) ) return ECL_EOF;
+    if( read != sizeof( head ) ) {
+             if( std::feof( fp ) )   return ECL_UNEXPECTED_EOF;
+        else if( std::ferror( fp ) ) return ECL_ERR_READ;
+        else                         return ECL_ERR_UNKNOWN;
+    }
 
     if( o.bigendian )
         to_host( &head, sizeof( head ), 1 );
@@ -266,19 +278,25 @@ int eclfio_get( std::FILE* fp,
 
     if( record ) {
         read = std::fread( record, head, 1, fp );
-        if( read != 1 ) return ECL_ERR_READ;
+        if( read != 1 ) {
+                 if( std::feof( fp ) )   return ECL_UNEXPECTED_EOF;
+            else if( std::ferror( fp ) ) return ECL_ERR_READ;
+            else                         return ECL_ERR_UNKNOWN;
+        }
     } else {
         /* read-buffer is zero, so skip this record instead of reading it */
         const auto err = std::fseek( fp, head, SEEK_CUR );
-        if( err ) return ECL_ERR_READ;
+        if( err ) {
+                 if( std::feof( fp ) )   return ECL_UNEXPECTED_EOF;
+            else if( std::ferror( fp ) ) return ECL_ERR_READ;
+            else                         return ECL_ERR_UNKNOWN;
+        }
     }
 
     const auto elems = head / o.elemsize;
 
-    if( o.transform and o.bigendian ) {
-        if( to_host( record, o.elemsize, elems ) )
-            return ECL_EINVAL;
-    }
+    if( o.transform and o.bigendian )
+        to_host( record, o.elemsize, elems );
 
     if( o.force_notail ) {
         if( recordsize ) *recordsize = elems;
@@ -290,7 +308,7 @@ int eclfio_get( std::FILE* fp,
     std::int32_t tail;
     read = std::fread( &tail, sizeof( tail ), 1, fp );
 
-    if( read == 1 and o.bigendian )
+    if( o.bigendian )
         to_host( &tail, sizeof( tail ), 1 );
 
     /*
@@ -316,7 +334,7 @@ int eclfio_get( std::FILE* fp,
     /*
      * last record, and ok to not have tail. don't rewind as this is a success
      */
-    if( read != 1 and feof( fp ) and o.allow_notail ) {
+    if( read != 1 and std::feof( fp ) and o.allow_notail ) {
         if( recordsize ) *recordsize = elems;
         guard.fp = tailguard.fp = nullptr;
         return ECL_OK;
@@ -330,7 +348,7 @@ int eclfio_get( std::FILE* fp,
         return ECL_INVALID_RECORD;
 
     /* read failed, but not at end-of-file */
-    if( read != 1 and ferror( fp ) )
+    if( read != 1 and std::ferror( fp ) )
         return ECL_ERR_READ;
 
     /*
@@ -338,7 +356,7 @@ int eclfio_get( std::FILE* fp,
      * as invalid and roll back the file pointer
      */
     if( read != 1 and feof( fp ) and not o.allow_notail )
-        return ECL_INVALID_RECORD;
+        return ECL_UNEXPECTED_EOF;
 
     return ECL_ERR_UNKNOWN;
 } catch( std::exception& ) {

--- a/lib/src/fortio.cpp
+++ b/lib/src/fortio.cpp
@@ -523,7 +523,7 @@ int eclfio_array_get( std::FILE* fp,
         if( dst ) dst += size * len * items;
     } while( nmemb > 0 );
 
-    if( nmemb < 0 ) return ECL_UNALIGNED_ARRAY;
+    if( nmemb < 0 ) return ECL_ERR_UNKNOWN;
 
     return ECL_OK;
 }

--- a/lib/src/fortio.cpp
+++ b/lib/src/fortio.cpp
@@ -224,7 +224,7 @@ int eclfio_sizeof( std::FILE* fp, const char* opts, int32_t* out ) try {
     return ECL_OK;
 
 } catch( std::exception& ) {
-    return ECL_ERR_SEEK;
+    return ECL_INCONSISTENT_STATE;
 }
 
 int eclfio_skip( FILE* fp, const char* opts, int n ) try {
@@ -241,7 +241,7 @@ int eclfio_skip( FILE* fp, const char* opts, int n ) try {
     guard.fp = nullptr;
     return ECL_OK;
 } catch( std::exception& ) {
-    return ECL_ERR_SEEK;
+    return ECL_INCONSISTENT_STATE;
 }
 
 int eclfio_get( std::FILE* fp,
@@ -360,7 +360,7 @@ int eclfio_get( std::FILE* fp,
 
     return ECL_ERR_UNKNOWN;
 } catch( std::exception& ) {
-    return ECL_ERR_SEEK;
+    return ECL_INCONSISTENT_STATE;
 }
 
 int eclfio_put( std::FILE* fp,
@@ -425,5 +425,5 @@ int eclfio_put( std::FILE* fp,
     return ECL_OK;
 
 } catch( std::exception& ) {
-    return ECL_ERR_SEEK;
+    return ECL_INCONSISTENT_STATE;
 }

--- a/lib/src/fortio.cpp
+++ b/lib/src/fortio.cpp
@@ -524,14 +524,14 @@ int eclfio_array_put( std::FILE* fp,
     const auto size = parse_opts( opts ).elemsize;
 
     auto* src = static_cast< const char* >( array );
-    while( nmemb > 0 ) {
+    do {
         const auto items = std::min( nmemb, blocksize );
         const auto err = eclfio_put( fp, opts, len * items, src );
         if( err ) return err;
 
         nmemb -= items;
         if( src ) src += size * len * items;
-    }
+    } while( nmemb > 0 );
 
     return ECL_OK;
 }

--- a/lib/src/fortio.cpp
+++ b/lib/src/fortio.cpp
@@ -448,7 +448,7 @@ int eclfio_put( std::FILE* fp,
 }
 
 int ecl_default_blocksize( int size, int type ) {
-    switch( type ) {
+    switch( size ) {
         case ECL_BLOCKSIZE_NUMERIC:
             return ECL_DEFAULT_BLOCKSIZE_NUMERIC;
 

--- a/lib/test/fortio.cpp
+++ b/lib/test/fortio.cpp
@@ -18,6 +18,63 @@ struct fcloser {
 
 using ufile = std::unique_ptr< std::FILE, fcloser >;
 
+/*
+ * Until the scope of network <-> host transformation is known, just copy the
+ * implementation into the test program to avoid hassle with linking winsock
+ */
+#ifdef HOST_BIG_ENDIAN
+
+template< typename T > constexpr T hton( T value ) noexcept { return value; }
+template< typename T > constexpr T ntoh( T value ) noexcept { return value; }
+
+#else
+
+template< typename T >
+constexpr typename std::enable_if< sizeof(T) == 1, T >::type
+hton( T value ) noexcept {
+    return value;
+}
+
+template< typename T >
+constexpr typename std::enable_if< sizeof(T) == 2, T >::type
+hton( T value ) noexcept {
+   return  ((value & 0x00FF) << 8)
+         | ((value & 0xFF00) >> 8)
+         ;
+}
+
+template< typename T >
+constexpr typename std::enable_if< sizeof(T) == 4, T >::type
+hton( T value ) noexcept {
+   return  ((value & 0x000000FF) << 24)
+         | ((value & 0x0000FF00) <<  8)
+         | ((value & 0x00FF0000) >>  8)
+         | ((value & 0xFF000000) >> 24)
+         ;
+}
+
+template< typename T >
+constexpr typename std::enable_if< sizeof(T) == 8, T >::type
+hton( T value ) noexcept {
+   return  ((value & 0xFF00000000000000ull) >> 56)
+         | ((value & 0x00FF000000000000ull) >> 40)
+         | ((value & 0x0000FF0000000000ull) >> 24)
+         | ((value & 0x000000FF00000000ull) >>  8)
+         | ((value & 0x00000000FF000000ull) <<  8)
+         | ((value & 0x0000000000FF0000ull) << 24)
+         | ((value & 0x000000000000FF00ull) << 40)
+         | ((value & 0x00000000000000FFull) << 56)
+         ;
+}
+
+// preserve the ntoh name for symmetry
+template< typename T >
+constexpr T ntoh( T value ) noexcept {
+    return hton( value );
+}
+
+#endif
+
 }
 
 using Catch::Matchers::Equals;
@@ -41,16 +98,56 @@ TEST_CASE("records with broken tail can be read", "[fortio][f77]") {
 
     std::int32_t size = src.size();
 
-    for( bool write_tail : { true, false } ) SECTION(
-          write_tail
-        ? "tail is valid, but mismatch with head"
-        : "tail is missing" ) {
+    SECTION( "missing tail" ) {
 
-        if( write_tail ) {
-            auto tail = head + 1;
-            auto elems = std::fwrite( &tail, sizeof( head ), 1, fp );
-            REQUIRE_THAT( elems, FwriteCount( 1 ) );
+        SECTION("querying size is not affected") {
+            std::rewind( fp );
+
+            Err err = eclfio_sizeof( fp, "e", &size );
+            CHECK( err == Err::ok() );
+            CHECK( size == 10 );
         }
+
+        SECTION("failure with strict read") {
+            std::rewind( fp );
+            auto out = src;
+            const auto pos = std::ftell( fp );
+
+            Err err = eclfio_get( fp, "e", &size, out.data() );
+            CHECK( err == Err::unexpected_eof() );
+            CHECK( size == 10 );
+            CHECK( pos == std::ftell( fp ) );
+        }
+
+        SECTION("success with allow-notail ($)") {
+            std::rewind( fp );
+            auto out = src;
+            const auto pos = std::ftell( fp );
+
+            Err err = eclfio_get( fp, "e$", &size, out.data() );
+            CHECK( err == Err::ok() );
+            CHECK( size == 10 );
+            CHECK( pos < std::ftell( fp ) );
+            CHECK_THAT( out, Equals( src ) );
+        }
+
+        SECTION("success with force-notail (~)") {
+            std::rewind( fp );
+            auto out = src;
+            const auto pos = std::ftell( fp );
+
+            Err err = eclfio_get( fp, "e~", &size, out.data() );
+            CHECK( err == Err::ok() );
+            CHECK( size == 10 );
+            CHECK( pos < std::ftell( fp ) );
+            CHECK_THAT( out, Equals( src ) );
+        }
+    }
+
+    SECTION( "mismatching between head and tail" ) {
+        auto tail = head + 1;
+        auto elems = std::fwrite( &tail, sizeof( head ), 1, fp );
+        REQUIRE_THAT( elems, FwriteCount( 1 ) );
 
         SECTION("querying size is not affected") {
             std::rewind( fp );
@@ -97,7 +194,7 @@ TEST_CASE("records with broken tail can be read", "[fortio][f77]") {
     }
 }
 
-TEST_CASE("record with valid, but wrong head", "[fortio][f77]") {
+TEST_CASE("record with valid, but too small body", "[fortio][f77]") {
     ufile handle( std::tmpfile() );
     REQUIRE( handle );
     auto* fp = handle.get();
@@ -117,7 +214,7 @@ TEST_CASE("record with valid, but wrong head", "[fortio][f77]") {
     std::int32_t size = out.size();
     Err err = eclfio_get( fp, "e", &size, out.data() );
 
-    CHECK( err == Err::read() );
+    CHECK( err == Err::unexpected_eof() );
     CHECK( pos == std::ftell( fp ) );
     CHECK( size == out.size() );
 }
@@ -149,5 +246,101 @@ TEST_CASE("record with invalid head", "[fortio][f77]") {
         CHECK( err == Err::invalid_record() );
         CHECK( pos == std::ftell( fp ) );
         CHECK( size == src.size() );
+    }
+}
+
+TEST_CASE("encountering EOF after valid block", "[fortio][f77]") {
+    ufile handle( std::tmpfile() );
+    REQUIRE( handle );
+    auto* fp = handle.get();
+
+    SECTION("in empty file") {
+        std::int32_t size = 10;
+        Err err = eclfio_get( fp, "", &size, nullptr );
+        CHECK( err == Err::eof() );
+    }
+
+    SECTION("after single, empty block") {
+        std::int32_t head = 0;
+        std::fwrite( &head, sizeof( head ), 1, fp );
+        std::fwrite( &head, sizeof( head ), 1, fp );
+        std::rewind( fp );
+
+        std::int32_t size = -1;
+        Err err = eclfio_sizeof( fp, "", &size );
+        CHECK( err == Err::ok() );
+        CHECK( size == 0 );
+
+        err = eclfio_get( fp, "", &size, nullptr );
+
+        CHECK( err == Err::ok() );
+        CHECK( size == 0 );
+
+        err = eclfio_get( fp, "", &size, nullptr );
+        CHECK( err == Err::eof() );
+    }
+
+    SECTION("after single, non-empty block") {
+        std::int32_t head = 10;
+        std::vector< std::int32_t > src( 10 );
+
+        Err err = eclfio_put( fp, "", head, src.data() );
+        REQUIRE( err == Err::ok() );
+        std::rewind( fp );
+
+        std::int32_t size = head;
+        err = eclfio_get( fp, "", &size, nullptr );
+
+        CHECK( err == Err::ok() );
+        CHECK( size == 10 );
+
+        err = eclfio_get( fp, "", &size, nullptr );
+        CHECK( err == Err::eof() );
+    }
+}
+
+TEST_CASE("unexpected EOF in block body", "[fortio][f77]") {
+    ufile handle( std::tmpfile() );
+    REQUIRE( handle );
+    auto* fp = handle.get();
+
+    /* allocate more room than we write (except the write is too short) */
+    std::vector< std::int32_t > out( 4, 0 );
+
+    std::int32_t head = hton( std::int32_t( 3 * sizeof( std::int32_t ) ) );
+    std::fwrite( &head, sizeof( head ), 1, fp );
+    std::fwrite( &head, sizeof( head ), 1, fp );
+    std::fwrite( &head, sizeof( head ), 1, fp );
+
+    std::rewind( fp );
+    std::int32_t size = sizeof( std::int32_t ) * out.size();
+
+    SECTION( "when reading body" ) {
+        Err err = eclfio_get( fp, "", &size, out.data() );
+
+        CHECK( err == Err::unexpected_eof() );
+        /* expect size not to be modified after failed call */
+        CHECK( size == 16 );
+    }
+
+    SECTION( "when skipping body" ) {
+        /* skipping the record should raise the same error */
+        Err err = eclfio_get( fp, "", &size, nullptr );
+        CHECK( err == Err::unexpected_eof() );
+        CHECK( size == 16 );
+    }
+
+    SECTION( "when reading the unbounded body" ) {
+        /* reading without size hint should not affect unexpected EOFs */
+        Err err = eclfio_get( fp, "", nullptr, out.data() );
+        CHECK( err == Err::unexpected_eof() );
+        CHECK( size == 16 );
+    }
+
+    SECTION( "when skipping the unbounded body" ) {
+        /* skipping without size hint should not affect unexpected EOFs */
+        Err err = eclfio_get( fp, "", nullptr, nullptr );
+        CHECK( err == Err::unexpected_eof() );
+        CHECK( size == 16 );
     }
 }

--- a/lib/test/fortio.cpp
+++ b/lib/test/fortio.cpp
@@ -249,6 +249,28 @@ TEST_CASE("record with invalid head", "[fortio][f77]") {
     }
 }
 
+TEST_CASE("requesting string does not consider endianness", "[fortio][f77]") {
+    ufile handle( std::tmpfile() );
+    REQUIRE( handle );
+    auto* fp = handle.get();
+
+    const std::string expected = "FOPT    MINISTEP";
+    Err err = eclfio_put( fp, "b", 16, expected.data() );
+    REQUIRE( err == Err::ok() );
+    std::rewind( fp );
+
+    for( const std::string opts : { "s", "st", "ts", "fst" } )
+    SECTION( "with options: " + opts ) {
+        char data[17]  = { 0 };
+        std::int32_t size = 2;
+        err = eclfio_get( fp, opts.c_str(), &size, data );
+
+        CHECK( err == Err::ok() );
+        CHECK( data == expected );
+        CHECK( size == 2 );
+    }
+}
+
 TEST_CASE("encountering EOF after valid block", "[fortio][f77]") {
     ufile handle( std::tmpfile() );
     REQUIRE( handle );

--- a/lib/test/matchers.hpp
+++ b/lib/test/matchers.hpp
@@ -46,6 +46,8 @@ struct Err {
     static Err ok()                { return ECL_OK; }
     static Err invalid_record()    { return ECL_INVALID_RECORD; }
     static Err read()              { return ECL_ERR_READ; }
+    static Err eof()               { return ECL_EOF; }
+    static Err unexpected_eof()    { return ECL_UNEXPECTED_EOF; }
 
     int expected;
 };
@@ -55,13 +57,16 @@ template<>
 struct StringMaker< Err > {
     static std::string convert( const Err& err ) {
         switch( err.expected ) {
-            case ECL_OK:                return "OK";
-            case ECL_ERR_SEEK:          return "SEEK";
-            case ECL_ERR_READ:          return "READ";
-            case ECL_ERR_WRITE:         return "WRITE";
-            case ECL_INVALID_RECORD:    return "INVALID RECORD";
-            case ECL_EINVAL:            return "INVALID ARGUMENT";
-            case ECL_ERR_UNKNOWN:       return "UNKNOWN";
+            case ECL_OK:                    return "OK";
+            case ECL_ERR_SEEK:              return "SEEK";
+            case ECL_ERR_READ:              return "READ";
+            case ECL_ERR_WRITE:             return "WRITE";
+            case ECL_INVALID_RECORD:        return "INVALID RECORD";
+            case ECL_EINVAL:                return "INVALID ARGUMENT";
+            case ECL_ERR_UNKNOWN:           return "UNKNOWN";
+            case ECL_INCONSISTENT_STATE:    return "INCONSISTENT STATE";
+            case ECL_EOF:                   return "EOF";
+            case ECL_UNEXPECTED_EOF:        return "UNEXPECTED EOF";
         }
 
         return "Unknown error";


### PR DESCRIPTION
These functions provide an abstraction for the eclipse detail of large
arrays being written across multiple smaller physical blocks.

In effect, it enables reading an eclipse record (the header
keyword-size-type, followed by the array) as:

    header = eclfio_get()
    nmemb = parse-header(header)
    return eclfio_array_get(nmemb)


Remaining work:

- tests!
- some considerations on return types
- port ecl2 to use this

I also propose we add a new data type in opts, `C` or `s`, for the fixed len-8 string. That means the `len` argument to the array function really only makes sense for var-strings (which are special) funky cool functionality where you emulate 64-bit ints by merging two consecutive int32. 

**Task**
_Short description of the task_


**Approach**
_Short description of the approach_


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
