### PR TITLE
Convert TestArea to Cxx

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -252,6 +252,7 @@ foreach (name   ert_util_alloc_file_components
                 ert_util_datetime
                 ert_util_normal_path
                 ert_util_mkdir_p
+                test_area
         )
 
     add_executable(${name} util/tests/${name}.cpp)

--- a/lib/ecl/tests/ecl_fortio.cpp
+++ b/lib/ecl/tests/ecl_fortio.cpp
@@ -111,7 +111,7 @@ void test_open_close_read( const char * filename ) {
 
 
 void test_fread_truncated_data() {
-  test_work_area_type * work_area = test_work_area_alloc("fortio_truncated" );
+  ecl::util::TestArea work_area("fortio_truncated");
   {
     const size_t buffer_size = 1000;
     char * buffer = (char *) util_malloc( buffer_size );
@@ -136,11 +136,10 @@ void test_fread_truncated_data() {
     }
     free( buffer );
   }
-  test_work_area_free( work_area );
 }
 
 void test_fread_truncated_head() {
-  test_work_area_type * work_area = test_work_area_alloc("fortio_truncated" );
+  ecl::util::TestArea work_area("fortio_truncated");
   {
     {
       FILE * stream = util_fopen("PRESSURE" , "w");
@@ -156,12 +155,11 @@ void test_fread_truncated_head() {
       fortio_fclose( fortio );
     }
   }
-  test_work_area_free( work_area );
 }
 
 
 void test_fread_truncated_tail() {
-  test_work_area_type * work_area = test_work_area_alloc("fortio_truncated2" );
+  ecl::util::TestArea work_area("fortio_truncated3");
   {
     const size_t buffer_size = 1000;
     char * buffer = (char *) util_malloc( buffer_size );
@@ -183,12 +181,11 @@ void test_fread_truncated_tail() {
     }
     free( buffer );
   }
-  test_work_area_free( work_area );
 }
 
 
 void test_fread_invalid_tail() {
-  test_work_area_type * work_area = test_work_area_alloc("fortio_invalid" );
+  ecl::util::TestArea work_area("fortio_invalid");
   int record_size = 10;
   char * buffer = (char *) util_malloc( record_size );
   {
@@ -215,13 +212,12 @@ void test_fread_invalid_tail() {
   }
 
   free( buffer );
-  test_work_area_free( work_area );
 }
 
 
 
 void test_at_eof() {
-  test_work_area_type * work_area = test_work_area_alloc("fortio_truncated2" );
+  ecl::util::TestArea work_area("fortio_truncated3");
   {
     fortio_type * fortio = fortio_open_writer("PRESSURE" , false , true);
     char * buffer = (char *) util_malloc( 100 );
@@ -242,13 +238,11 @@ void test_at_eof() {
 
     fortio_fclose( fortio );
   }
-
-  test_work_area_free( work_area );
 }
 
 
 void test_fseek() {
-  test_work_area_type * work_area = test_work_area_alloc("fortio_fseek" );
+  ecl::util::TestArea work_area("fortio_fseek");
   {
     fortio_type * fortio = fortio_open_writer("PRESSURE" , false , true);
     char * buffer = (char *) util_malloc( 100 );
@@ -261,8 +255,6 @@ void test_fseek() {
   {
     fortio_type * fortio = fortio_open_reader("PRESSURE" , false , true);
 
-
-    printf("Starting fssek test \n");
     test_assert_true( fortio_fseek( fortio , 0 , SEEK_SET ));
     test_assert_true( fortio_fseek( fortio , 0 , SEEK_END ));
     test_assert_false( fortio_fseek( fortio , 100000 , SEEK_END));
@@ -270,14 +262,12 @@ void test_fseek() {
 
     fortio_fclose( fortio );
   }
-
-  test_work_area_free( work_area );
 }
 
 
 
 void test_write_failure() {
-  test_work_area_type * work_area = test_work_area_alloc("fortio_fseek" );
+  ecl::util::TestArea work_area("fortio_truncated");
   {
     fortio_type * fortio = fortio_open_writer("PRESSURE" , false , true);
     char * buffer = (char *) util_malloc( 100 );
@@ -292,7 +282,6 @@ void test_write_failure() {
     test_assert_false( util_file_exists( "PRESSURE"));
 
   }
-  test_work_area_free( work_area );
 }
 
 
@@ -317,10 +306,9 @@ int main( int argc , char ** argv) {
 
     test_write( "/tmp/path/does/not/exist" , false );
     {
-      test_work_area_type * work_area = test_work_area_alloc("ecl_fortio.write" );
+      ecl::util::TestArea work_area("ecl_fortio_write");
       util_make_path("path");
       test_write( "path/file.x" , true );
-      test_work_area_free( work_area );
     }
 
     test_write_failure();

--- a/lib/include/ert/util/test_work_area.hpp
+++ b/lib/include/ert/util/test_work_area.hpp
@@ -20,33 +20,58 @@
 #ifndef ERT_TEST_WORK_AREA_H
 #define ERT_TEST_WORK_AREA_H
 
+#include <string>
+
+namespace ecl {
+namespace util {
+
+class TestArea {
+public:
+    TestArea(const std::string& test_name, bool store_area = false);
+    ~TestArea();
+    const std::string& test_cwd() const;
+    const std::string& original_cwd() const;
+
+    void copy_directory(const std::string input_directory) const;
+    void copy_directory_content(const std::string input_directory) const;
+    bool copy_parent(const std::string input_path) const;
+    bool copy_parent_content(const std::string original_path) const;
+
+    void copy_file(const std::string& input_src_file) const;
+    std::string original_path(const std::string& input_path) const;
+
+private:
+    bool store;
+    std::string cwd;
+    std::string org_cwd;
+};
+
+
+}
+}
+
+typedef ecl::util::TestArea test_work_area_type;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <stdbool.h>
 
-#include <ert/util/type_macros.hpp>
-
-  typedef struct test_work_area_struct test_work_area_type;
-
   char                * test_work_area_alloc_input_path( const test_work_area_type * work_area , const char * input_path );
   test_work_area_type * test_work_area_alloc(const char * test_name );
+  test_work_area_type * test_work_area_alloc__(const char * test_name, bool store_area );
   test_work_area_type * test_work_area_alloc_relative(const char * prefix , const char * test_path);
-  void                  test_work_area_set_store( test_work_area_type * work_area , bool store);
 
   void                  test_work_area_free(test_work_area_type * work_area);
   const char          * test_work_area_get_cwd( const test_work_area_type * work_area );
   const char          * test_work_area_get_original_cwd( const test_work_area_type * work_area );
-  void                  test_work_area_install_file( test_work_area_type * work_area , const char * input_src_file );
-  void                  test_work_area_copy_directory( test_work_area_type * work_area , const char * input_directory);
-  void                  test_work_area_copy_directory_content( test_work_area_type * work_area , const char * input_directory);
-  void                  test_work_area_copy_file( test_work_area_type * work_area , const char * input_file);
-  bool                  test_work_area_copy_parent_directory( test_work_area_type * work_area , const char * input_path);
-  bool                  test_work_area_copy_parent_content( test_work_area_type * work_area , const char * input_path);
-  void                  test_work_area_sync( test_work_area_type * work_area);
-
-  UTIL_IS_INSTANCE_HEADER( test_work_area );
+  void                  test_work_area_install_file( const test_work_area_type * work_area , const char * input_src_file );
+  void                  test_work_area_copy_directory( const test_work_area_type * work_area , const char * input_directory);
+  void                  test_work_area_copy_directory_content( const test_work_area_type * work_area , const char * input_directory);
+  void                  test_work_area_copy_file( const test_work_area_type * work_area , const char * input_file);
+  bool                  test_work_area_copy_parent_directory( const test_work_area_type * work_area , const char * input_path);
+  bool                  test_work_area_copy_parent_content( const test_work_area_type * work_area , const char * input_path);
 
 #ifdef __cplusplus
 }

--- a/lib/util/test_work_area.cpp
+++ b/lib/util/test_work_area.cpp
@@ -25,19 +25,16 @@
 #include <paths.h>
 #endif
 
+#include <ert/util/ert_api_config.hpp>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 
 #include <ert/util/util.h>
 #include <ert/util/test_work_area.hpp>
-#include <ert/util/type_macros.hpp>
 
-#include <ert/util/ert_api_config.hpp>
-#ifdef ERT_HAVE_OPENDIR
-#include <sys/types.h>
-#include <dirent.h>
-#endif
+#include "detail/util/path.hpp"
 
 /*
   This file implements a small work area implementation to be used for
@@ -96,79 +93,65 @@
 
 #define TEST_WORK_AREA_TYPE_ID 1107355
 
-struct test_work_area_struct {
-  UTIL_TYPE_ID_DECLARATION;
-  bool        store;
-  char      * cwd;
-  char      * original_cwd;
+static char * test_work_area_alloc_prefix( ) {
+#ifdef HAVE_WINDOWS_GET_TEMP_PATH
 
-  /*
-    There have been issues where a test like this:
+    char tmp_path[MAX_PATH];
+    GetTempPath( MAX_PATH , tmp_path );
+    return util_alloc_string_copy( tmp_path );
 
-     1. Create new file in test area.
-     2. Open file for reading.
-
-    Fail randomly at step 2 with "File not found", although the file
-    is clearly there when checking afterwards. Inspired by this
-    article: https:/lwn.net/Articles/457667/ we try to call fsync() on
-    the directory file descriptor.
-  */
-#ifdef ERT_HAVE_OPENDIR
-  DIR       * dir_stream;
-#endif
-  int         dir_fd;
-};
-
-
-
-
-static test_work_area_type * test_work_area_alloc__(const char * prefix , const char * test_path) {
-  test_work_area_type * work_area = NULL;
-
-  if (util_is_directory( prefix )) {
-    char * test_cwd = util_alloc_sprintf(FULL_PATH_FMT , prefix , test_path );
-    util_make_path( test_cwd );
-    if (true) {
-      work_area = (test_work_area_type*)util_malloc( sizeof * work_area );
-
-      UTIL_TYPE_ID_INIT( work_area , TEST_WORK_AREA_TYPE_ID );
-      work_area->original_cwd = util_alloc_cwd();
-      work_area->cwd = test_cwd;
-      if(util_chdir( work_area->cwd ) != 0)
-        util_abort("%s: Failed to move into temporary directory: %s", __func__, test_cwd);
-
-      test_work_area_set_store( work_area , DEFAULT_STORE);
-
-#ifdef ERT_HAVE_OPENDIR
-      work_area->dir_stream = opendir( work_area->cwd );
-      if (work_area->dir_stream)
-        work_area->dir_fd = dirfd( work_area->dir_stream );
-      else
-        work_area->dir_fd = -1;
 #else
-      work_area->dir_fd = -1
+
+    const char * prefix_path = getenv("TMPDIR");
+
+#ifdef P_tmpdir
+    if (!prefix_path)
+        prefix_path = P_tmpdir;
 #endif
-    } else
-      free( test_cwd );
+
+    if (!prefix_path)
+        prefix_path = _PATH_TMP;
+
+    return util_alloc_realpath(prefix_path);
+
+#endif
+}
+
+
+
+namespace ecl {
+namespace util {
+
+static bool test_work_area_copy_parent__( const TestArea * work_area , const std::string& input_path, bool copy_content) {
+  char * full_path;
+
+  if (util_is_abs_path( input_path.c_str() ))
+    full_path = util_alloc_string_copy( input_path.c_str() );
+  else
+    full_path = util_alloc_filename( work_area->original_cwd().c_str( ) , input_path.c_str() , NULL);
+
+  if (util_entry_exists( full_path)) {
+    char * parent_path = util_alloc_parent_path( full_path );
+
+    if (copy_content)
+      work_area->copy_directory_content(std::string(parent_path));
+    else
+      work_area->copy_directory(std::string(parent_path));
+
+    free( full_path );
+    free( parent_path );
+    return true;
+  } else {
+    free( full_path );
+    return false;
   }
-  return work_area;
 }
 
 
-test_work_area_type * test_work_area_alloc_relative(const char * prefix , const char * test_path) {
-  return test_work_area_alloc__(prefix , test_path);
-}
-
-
-test_work_area_type * temp_area_alloc_relative(const char * prefix , const char * test_path) {
-  return test_work_area_alloc__(prefix , test_path);
-}
-
-
-UTIL_IS_INSTANCE_FUNCTION( test_work_area , TEST_WORK_AREA_TYPE_ID)
-
-static test_work_area_type * test_work_area_alloc_with_prefix(const char * prefix , const char * test_name) {
-  if (test_name) {
+TestArea::TestArea(const std::string& test_name, bool store_area) :
+    store(store_area)
+{
+    char * prefix = test_work_area_alloc_prefix();
     unsigned int random_int;
     util_fread_dev_urandom( sizeof random_int, (char *) &random_int);
     random_int = random_int % 100000000;
@@ -180,201 +163,177 @@ static test_work_area_type * test_work_area_alloc_with_prefix(const char * prefi
 #else
     char * user_name =  util_alloc_sprintf("ert-test-%08u" , random_int);
 #endif
-    char * test_path = util_alloc_sprintf( TEST_PATH_FMT , user_name , test_name , random_int);
-    test_work_area_type * work_area = test_work_area_alloc__( prefix , test_path );
+
+    char * test_path = util_alloc_sprintf( TEST_PATH_FMT , user_name , test_name.c_str() , random_int);
+    char * test_cwd = util_alloc_sprintf(FULL_PATH_FMT , prefix , test_path );
+    util_make_path( test_cwd );
+
+    {
+        char * cwd_tmp = util_alloc_cwd();
+        this->org_cwd = cwd_tmp;
+        free(cwd_tmp);
+    }
+    this->cwd = test_cwd;
+    if (util_chdir( this->cwd.c_str() ) != 0)
+        util_abort("%s: Failed to move into temporary directory: %s", __func__, this->cwd.c_str());
+
     free( test_path );
     free( user_name );
-    return work_area;
-  } else
+    free( test_cwd );
+    free( prefix );
+}
+
+TestArea::~TestArea() {
+    if (!this->store)
+        util_clear_directory( this->cwd.c_str() , true , true );
+
+    util_chdir( this->org_cwd.c_str() );
+}
+
+const std::string& TestArea::test_cwd() const {
+    return this->cwd;
+}
+
+const std::string& TestArea::original_cwd() const {
+    return this->org_cwd;
+}
+
+std::string TestArea::original_path(const std::string& input_path) const {
+  if (util_is_abs_path( input_path.c_str() ))
+    return std::string(input_path);
+  else {
+    char * fname = util_alloc_filename( this->original_cwd().c_str(), input_path.c_str() , NULL);
+
+    std::string return_string = std::string(fname);
+    free(fname);
+
+    return return_string;
+  }
+}
+
+
+void TestArea::copy_file(const std::string& input_src_file) const {
+  std::string src_file = this->original_path(input_src_file);
+
+  if (util_file_exists( src_file.c_str() )) {
+    char * target_name = util_split_alloc_filename( input_src_file.c_str() );
+    char * target_file = util_alloc_filename( this->test_cwd().c_str() , target_name , NULL );
+    util_copy_file( src_file.c_str(), target_file );
+    free( target_file );
+    free( target_name );
+  }
+}
+
+void TestArea::copy_directory(const std::string input_directory) const {
+  std::string src_directory = this->original_path(input_directory);
+  util_copy_directory(src_directory.c_str() , this->test_cwd().c_str() );
+}
+
+void TestArea::copy_directory_content(const std::string input_directory) const {
+  std::string src_directory = this->original_path(input_directory);
+  util_copy_directory_content(src_directory.c_str() , this->test_cwd().c_str() );
+}
+
+bool TestArea::copy_parent(const std::string input_path) const {
+  return test_work_area_copy_parent__(this, input_path, false);
+}
+
+bool TestArea::copy_parent_content(const std::string input_path) const {
+  return test_work_area_copy_parent__(this, input_path, true);
+}
+
+}
+}
+
+/*****************************************************************/
+/* C API */
+
+test_work_area_type * test_work_area_alloc__(const char * test_name, bool store_area) {
+  if (test_name)
+    return new ecl::util::TestArea(test_name, store_area);
+  else
     return NULL;
 }
 
 
-static char * test_work_area_alloc_prefix( ) {
-#ifdef HAVE_WINDOWS_GET_TEMP_PATH
-
-  char tmp_path[MAX_PATH];
-  GetTempPath( MAX_PATH , tmp_path );
-  return util_alloc_string_copy( tmp_path );
-
-#else
-
-  const char * prefix_path = getenv("TMPDIR");
-
-  #ifdef P_tmpdir
-  if (!prefix_path)
-    prefix_path = P_tmpdir;
-  #endif
-
-  if (!prefix_path)
-    prefix_path = _PATH_TMP;
-
-  return util_alloc_realpath(prefix_path);
-
-#endif
-}
-
-
 test_work_area_type * test_work_area_alloc(const char * test_name) {
-  test_work_area_type * work_area;
-  {
-    char * tmp_prefix = test_work_area_alloc_prefix( );
-    work_area = test_work_area_alloc_with_prefix( tmp_prefix , test_name);
-    free( tmp_prefix );
-  }
-  return work_area;
+  return test_work_area_alloc__(test_name, false);
 }
 
 
-
-void test_work_area_set_store( test_work_area_type * work_area , bool store) {
-  work_area->store = store;
-}
-
-
-void test_work_area_sync( test_work_area_type * work_area) {
-#ifdef ERT_HAVE_OPENDIR
-  if (work_area->dir_fd >= 0)
-    fsync( work_area->dir_fd );
-#endif
-}
 
 
 void test_work_area_free(test_work_area_type * work_area) {
-  if (!work_area->store)
-    util_clear_directory( work_area->cwd , true , true );
-
-  util_chdir( work_area->original_cwd );
-
-#ifdef ERT_HAVE_OPENDIR
-  if (work_area->dir_stream)
-    closedir( work_area->dir_stream );
-#endif
-
-  free( work_area->original_cwd );
-  free( work_area->cwd );
-  free( work_area );
+  delete work_area;
 }
 
 
 const char * test_work_area_get_cwd( const test_work_area_type * work_area ) {
-  return work_area->cwd;
+  return work_area->test_cwd().c_str();
 }
 
 
 const char * test_work_area_get_original_cwd( const test_work_area_type * work_area ) {
-  return work_area->original_cwd;
+  return work_area->original_cwd().c_str();
 }
 
+
 char * test_work_area_alloc_input_path( const test_work_area_type * work_area , const char * input_path ) {
-  if (util_is_abs_path( input_path ))
-    return util_alloc_string_copy( input_path );
-  else {
-    return util_alloc_filename( work_area->original_cwd , input_path , NULL);
-  }
+  std::string relocated_input_path = work_area->original_path(std::string(input_path));
+  return util_alloc_string_copy(relocated_input_path.c_str());
 }
+
+
 
 
 /**
    The point of this function is that the test code should be able to
    access the file @input_file independent of the fact that it has
    changed path. If @input_file is an absolute path the function will
-   do nothing, if @input_file is a realtive path the function will
+   do nothing, if @input_file is a relative path the function will
    copy @input_file from the location relative to the original cwd to
    the corresponding location relative to the test cwd.
 */
-
-void test_work_area_install_file( test_work_area_type * work_area , const char * input_src_file ) {
-  if (util_is_abs_path( input_src_file ))
+void test_work_area_install_file( const test_work_area_type * work_area , const char * input_src_file ) {
+  if (util_is_abs_path( input_src_file))
     return;
   else {
-    char * src_file = test_work_area_alloc_input_path( work_area , input_src_file );
-    char * src_path = NULL;
+    std::string src_file = work_area->original_path(input_src_file);
+    std::string src_path = ecl::util::path::dirname(input_src_file);
 
-    util_alloc_file_components( input_src_file , &src_path , NULL , NULL);
-    if (!util_entry_exists( src_path ))
-      util_make_path( src_path );
+    if (!util_entry_exists( src_path.c_str() ))
+      util_make_path( src_path.c_str() );
 
-    if (util_file_exists( src_file )) {
-      char * target_file   = util_alloc_filename( work_area->cwd , input_src_file , NULL );
-      util_copy_file( src_file , target_file );
+    if (util_file_exists( src_file.c_str() )) {
+      char * target_file   = util_alloc_filename( work_area->test_cwd().c_str(), input_src_file, NULL );
+      util_copy_file( src_file.c_str() , target_file );
       free( target_file );
     }
-    free( src_file );
-    free( src_path );
   }
 }
 
 
-void test_work_area_copy_directory( test_work_area_type * work_area , const char * input_directory) {
-  char * src_directory = test_work_area_alloc_input_path( work_area , input_directory );
-  util_copy_directory(src_directory , work_area->cwd );
-  free( src_directory );
-  test_work_area_sync( work_area );
+void test_work_area_copy_file( const test_work_area_type * work_area , const char * input_file) {
+  if (input_file)
+    work_area->copy_file(std::string(input_file));
 }
 
 
-void test_work_area_copy_directory_content( test_work_area_type * work_area , const char * input_directory) {
-  char * src_directory = test_work_area_alloc_input_path( work_area , input_directory );
-  util_copy_directory_content(src_directory , work_area->cwd );
-  free( src_directory );
-  test_work_area_sync( work_area );
+void test_work_area_copy_directory( const test_work_area_type * work_area , const char * input_directory) {
+  work_area->copy_directory(std::string(input_directory));
 }
 
 
-
-void test_work_area_copy_file( test_work_area_type * work_area , const char * input_file) {
-  if (input_file) {
-    char * src_file = test_work_area_alloc_input_path( work_area , input_file );
-
-    if (util_file_exists( src_file )) {
-      char * target_name = util_split_alloc_filename( input_file );
-      char * target_file = util_alloc_filename( work_area->cwd , target_name , NULL );
-      util_copy_file( src_file , target_file );
-      free( target_file );
-      free( target_name );
-    }
-    free( src_file );
-    test_work_area_sync( work_area );
-  }
+void test_work_area_copy_directory_content( const test_work_area_type * work_area , const char * input_directory) {
+  work_area->copy_directory_content(std::string(input_directory));
 }
 
 
-
-static bool test_work_area_copy_parent__( test_work_area_type * work_area , const char * input_path, bool copy_content) {
-  char * full_path;
-
-  if (util_is_abs_path( input_path ))
-    full_path = util_alloc_string_copy( input_path );
-  else
-    full_path = util_alloc_filename( work_area->original_cwd , input_path , NULL);
-
-  if (util_entry_exists( full_path)) {
-    char * parent_path = NULL;
-
-    parent_path = util_alloc_parent_path( full_path );
-
-    if (copy_content)
-      test_work_area_copy_directory_content( work_area , parent_path );
-    else
-      test_work_area_copy_directory( work_area , parent_path );
-
-    free( full_path );
-    free( parent_path );
-    test_work_area_sync( work_area );
-    return true;
-  } else {
-    free( full_path );
-    return false;
-  }
+bool test_work_area_copy_parent_directory( const test_work_area_type * work_area , const char * input_path) {
+  return work_area->copy_parent(std::string(input_path));
 }
 
 
-bool test_work_area_copy_parent_directory( test_work_area_type * work_area , const char * input_path) {
-  return test_work_area_copy_parent__( work_area , input_path , false );
-}
-
-
-bool test_work_area_copy_parent_content( test_work_area_type * work_area , const char * input_path) {
-  return test_work_area_copy_parent__( work_area , input_path , true );
+bool test_work_area_copy_parent_content( const test_work_area_type * work_area , const char * input_path) {
+  return work_area->copy_parent_content(std::string(input_path));
 }

--- a/lib/util/tests/ert_util_filename.cpp
+++ b/lib/util/tests/ert_util_filename.cpp
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <pwd.h>
 
+#include <ert/util/util.hpp>
 #include <ert/util/test_util.hpp>
 #include <ert/util/test_work_area.hpp>
 

--- a/lib/util/tests/ert_util_work_area.cpp
+++ b/lib/util/tests/ert_util_work_area.cpp
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 #include <pwd.h>
 
+#include <ert/util/util.hpp>
 #include <ert/util/test_util.hpp>
 #include <ert/util/test_work_area.hpp>
 
@@ -48,10 +49,9 @@ void test_get_original_cwd() {
 
 void create_test_area(const char * test_name , bool store) {
   char * pre_cwd = util_alloc_cwd();
-  test_work_area_type * work_area = test_work_area_alloc( test_name );
+  test_work_area_type * work_area = test_work_area_alloc__( test_name, store );
   char * work_path = util_alloc_string_copy( test_work_area_get_cwd( work_area ));
 
-  test_work_area_set_store( work_area , store );
   test_assert_true( util_is_directory( work_path ));
   test_work_area_free( work_area );
   test_assert_bool_equal( store , util_entry_exists( work_path ));
@@ -158,29 +158,11 @@ void test_copy_parent_content( const char * path ) {
 }
 
 
-void test_with_prefix() {
-  test_work_area_type * work_area = test_work_area_alloc( "with-prefix" );
-
-  util_make_path( "PREFIX" );
-  {
-    test_work_area_type * sub_area = test_work_area_alloc_relative("PREFIX" , "sub-work" );
-    test_assert_true( test_work_area_is_instance( sub_area ));
-    test_work_area_free( sub_area );
-    test_assert_true( util_entry_exists("PREFIX/sub-work"));
-  }
-  {
-    test_work_area_type * sub_area = test_work_area_alloc_relative("DoesNotExist" , "sub-work" );
-    test_assert_NULL( sub_area );
-  }
-  test_work_area_free( work_area );
-}
-
 
 void test_update_store() {
   {
-    test_work_area_type * work_area = test_work_area_alloc( "update-store1" );
+    test_work_area_type * work_area = test_work_area_alloc__( "update-store1" , true);
     char * work_cwd = util_alloc_string_copy( test_work_area_get_cwd( work_area ));
-    test_work_area_set_store( work_area , true );
     test_work_area_free( work_area );
     test_assert_true( util_entry_exists( work_cwd ));
   }
@@ -193,17 +175,15 @@ void test_update_store() {
   }
 
   {
-    test_work_area_type * work_area = test_work_area_alloc( "update-store3" );
+    test_work_area_type * work_area = test_work_area_alloc__( "update-store3" , false);
     char * work_cwd = util_alloc_string_copy( test_work_area_get_cwd( work_area ));
-    test_work_area_set_store( work_area , false );
     test_work_area_free( work_area );
     test_assert_false( util_entry_exists( work_cwd ));
   }
 
   {
-    test_work_area_type * work_area = test_work_area_alloc( "update-store4" );
+    test_work_area_type * work_area = test_work_area_alloc__( "update-store4" , true);
     char * work_cwd = util_alloc_string_copy( test_work_area_get_cwd( work_area ));
-    test_work_area_set_store( work_area , true);
     test_work_area_free( work_area );
     test_assert_true( util_entry_exists( work_cwd ));
   }
@@ -215,10 +195,12 @@ int main(int argc , char ** argv) {
   const char * abs_path_file = argv[2];
   const char * rel_directory = argv[3];
 
-  create_test_area("STORE-TEST" , true );
-  create_test_area("DEL-TEST" , false);
+  create_test_area("STORE-TEST", true );
+  create_test_area("DEL-TEST", false);
+
   test_install_file_exists( rel_path_file );
   test_install_file_exists( abs_path_file );
+
   test_copy_directory( rel_directory );
   test_input();
   test_get_cwd();
@@ -233,8 +215,6 @@ int main(int argc , char ** argv) {
   test_copy_parent_content( rel_path_file );
   test_copy_parent_content( abs_path_file );
 
-  test_with_prefix();
   test_update_store();
-
   exit(0);
 }

--- a/lib/util/tests/test_area.cpp
+++ b/lib/util/tests/test_area.cpp
@@ -1,0 +1,34 @@
+/*
+  Copyright (C) 2019  Equinor ASA, Norway.
+
+  The file 'test_area.cpp' is part of ERT - Ensemble based Reservoir Tool.
+
+  ERT is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.
+
+  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+  for more details.
+*/
+#include <string>
+
+#include <ert/util/test_util.hpp>
+#include <ert/util/test_work_area.hpp>
+
+void test_create() {
+    ecl::util::TestArea ta("Name");
+
+    test_assert_true( ta.test_cwd() != ta.original_cwd() );
+
+}
+
+
+
+int main(int argc, char **argv) {
+    test_create();
+}

--- a/python/ecl/util/test/test_area.py
+++ b/python/ecl/util/test/test_area.py
@@ -20,8 +20,7 @@ from ecl import EclPrototype
 
 
 class TestArea(BaseCClass):
-    _test_area_alloc           = EclPrototype("void* test_work_area_alloc( char* )" , bind = False)
-    _test_area_alloc_relative  = EclPrototype("void* test_work_area_alloc_relative( char* , char* )" , bind = False)
+    _test_area_alloc           = EclPrototype("void* test_work_area_alloc__( char*, bool )" , bind = False)
     _free                      = EclPrototype("void test_work_area_free( test_area )")
     _install_file              = EclPrototype("void test_work_area_install_file( test_area , char* )")
     _copy_directory            = EclPrototype("void test_work_area_copy_directory( test_area , char* )")
@@ -31,22 +30,13 @@ class TestArea(BaseCClass):
     _copy_parent_content       = EclPrototype("void test_work_area_copy_parent_content( test_area , char* )")
     _get_cwd                   = EclPrototype("char* test_work_area_get_cwd( test_area )")
     _get_original_cwd          = EclPrototype("char* test_work_area_get_original_cwd( test_area )")
-    _set_store                 = EclPrototype("void test_work_area_set_store( test_area , bool)")
-    _sync                      = EclPrototype("void test_work_area_sync( test_area )")
 
-    def __init__(self, test_name, prefix = None , store_area=False , c_ptr = None):
+    def __init__(self, test_name, store_area=False , c_ptr = None):
 
         if c_ptr is None:
-            if prefix:
-                if os.path.exists( prefix ):
-                    c_ptr = self._test_area_alloc_relative(prefix , test_name)
-                else:
-                    raise IOError("The prefix path:%s must exist" % prefix)
-            else:
-                c_ptr = self._test_area_alloc(test_name)
+            c_ptr = self._test_area_alloc(test_name, store_area)
 
         super(TestArea, self).__init__(c_ptr)
-        self.set_store( store_area )
 
 
     def get_original_cwd(self):
@@ -111,10 +101,6 @@ class TestArea(BaseCClass):
         self._free()
 
 
-    def set_store(self, store):
-        self._set_store(store)
-
-
     def getFullPath(self , path):
         if not os.path.exists( path ):
             raise IOError("Path not found:%s" % path)
@@ -125,22 +111,17 @@ class TestArea(BaseCClass):
         return os.path.join( self.get_cwd() , path )
 
 
-    def sync(self):
-        return self._sync( )
-
-
 
 class TestAreaContext(object):
-    def __init__(self, test_name, prefix = None , store_area=False):
+    def __init__(self, test_name, store_area=False):
         self.test_name = test_name
         self.store_area = store_area
-        self.prefix = prefix
 
     def __enter__(self):
         """
          @rtype: TestArea
         """
-        self.test_area = TestArea(self.test_name, prefix = self.prefix , store_area = self.store_area )
+        self.test_area = TestArea(self.test_name, store_area = self.store_area )
         return self.test_area
 
 

--- a/python/tests/ecl_tests/test_deprecation.py
+++ b/python/tests/ecl_tests/test_deprecation.py
@@ -43,7 +43,6 @@ class Deprecation_2_0_Test(EclTest):
             with openFortIO("TEST" , mode = FortIO.WRITE_MODE) as f:
                 kw.fwrite( f )
 
-            t.sync()
             f = EclFile( "TEST" )
 
 class Deprecation_1_9_Test(EclTest):

--- a/python/tests/ecl_tests/test_fortio.py
+++ b/python/tests/ecl_tests/test_fortio.py
@@ -77,8 +77,7 @@ class FortIOTest(EclTest):
                 kw1.fwrite(f)
                 pos1 = f.getPosition( )
                 kw2.fwrite(f)
-            
-            t.sync( ) 
+
             # Truncate file in read mode; should fail hard.
             with openFortIO("file") as f:
                 with self.assertRaises(IOError):
@@ -120,8 +119,6 @@ class FortIOTest(EclTest):
             with openFortIO("file" , mode = FortIO.WRITE_MODE) as f:
                 kw1.fwrite( f )
                 self.assertEqual( f.filename() , "file")
-
-            t.sync( ) 
 
             with openFortIO("file") as f:
                 kw2 = EclKW.fread( f )

--- a/python/tests/ecl_tests/test_removed.py
+++ b/python/tests/ecl_tests/test_removed.py
@@ -16,8 +16,6 @@ class Removed_2_1_Test(EclTest):
             with openFortIO("TEST" , mode = FortIO.WRITE_MODE) as f:
                 kw.fwrite( f )
 
-            t.sync()
-            
             f = EclFile( "TEST" )
             with self.assertRaises(NotImplementedError):
                 f.select_block( "KW" , 100 )
@@ -33,4 +31,4 @@ class Removed_2_1_Test(EclTest):
 
             with self.assertRaises(NotImplementedError):
                 EclFile.restart_block( "TEST" )
-                
+

--- a/python/tests/util_tests/test_rng.py
+++ b/python/tests/util_tests/test_rng.py
@@ -37,7 +37,6 @@ class RngTest(EclTest):
 
         with TestAreaContext("rng_state") as t:
             rng.saveState( "rng.txt" )
-            t.sync()
             val1 = rng.getInt()
             val2 = rng.getInt()
             rng.loadState( "rng.txt" )

--- a/python/tests/util_tests/test_work_area.py
+++ b/python/tests/util_tests/test_work_area.py
@@ -68,13 +68,6 @@ class WorkAreaTest(EclTest):
             with self.assertRaises(IOError):
                 test_area.copy_directory( "path1/file.txt" )
 
-    def test_sync(self):
-        with TestAreaContext("test_sync") as t:
-            with open("file.txt" , "w") as f:
-                f.write("content")
-
-            t.sync()
-            self.assertTrue( os.path.isfile( "file.txt"))
 
     def test_multiple_areas(self):
         original_dir = os.getcwd()


### PR DESCRIPTION
The `TestArea` which is used to create and populate a random directory in `/tmp` is extremely well suited for C++ automatic destructors. 

~~A small initial step which should be merged first is here: #563~~

**Update:** OK - now I consider this ~complete. The current implementation has both a C++ and a C api, the C api must be retained for Python compatibility, and also for external dependencies in libres/ert/opm. The current *implementation* is a quite ugly mix of `const char *` and `std::string` - but the API is at least consistent. Have only converted one actual test to use this; will make a followup PR changing all the tests when this is merged.

~~Please note that will *not* be green on Travis before:  Statoil/ert#233 is merged.~~