### PR TITLE
Fixed operator< for ecl_nnc_pair_type

### DIFF
--- a/lib/ecl/ecl_nnc_geometry.cpp
+++ b/lib/ecl/ecl_nnc_geometry.cpp
@@ -92,7 +92,7 @@ static bool ecl_nnc_cmp(const ecl_nnc_pair_type& nnc1, const ecl_nnc_pair_type& 
   if (nnc1.global_index2 != nnc2.global_index2)
     return nnc1.global_index2 < nnc2.global_index2;
 
-  return true;
+  return false;
 }
 
 


### PR DESCRIPTION
The previous implementation returned true even when the compared objects were equal, and that made std:sort screw up the memory on some cases

For instance, the problem lead to a segmentation fault in ResInsight when loading certain grids

