### PR TITLE
Fixed operator< for ecl_nnc_pair_type (Backport to 2.3)

### DIFF
--- a/lib/ecl/ecl_nnc_geometry.cpp
+++ b/lib/ecl/ecl_nnc_geometry.cpp
@@ -92,7 +92,7 @@ static bool ecl_nnc_cmp(const ecl_nnc_pair_type& nnc1, const ecl_nnc_pair_type& 
   if (nnc1.global_index2 != nnc2.global_index2)
     return nnc1.global_index2 < nnc2.global_index2;
 
-  return true;
+  return false;
 }
 
 


### PR DESCRIPTION
Backport of https://github.com/equinor/libecl/pull/565 to version 2.3