### PR TITLE
Fix requirements.txt for pythonversion != 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pandas
 sphinx
 future
 six
-functools32
+functools32;python_version=='2.7'


### PR DESCRIPTION
**Issue**
Resolves #573 

**Approach**
Added [environment marker](https://www.python.org/dev/peps/pep-0508/#environment-markers) to the [`functools32`](https://pypi.org/project/functools32/) dependency, in order to avoid [error thrown on python 3](https://github.com/michilu/python-functools32/blob/master/setup.py#L8-L10).
