### PR TITLE
Fix code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-*       @markusdregi
-*       @lars-petter-hauge
-*       @andreabrambilla
-*       @pgdr
-*       @jokva
+*       @markusdregi @lars-petter-hauge @andreabrambilla @pgdr @jokva


### PR DESCRIPTION
**Issue**
Apparently the syntax of the `.github/CODE_OWNERS` file was wrong and hence only the last one, being @jokva was interpreted. This PR should resolve that issue, more info in: https://help.github.com/articles/about-code-owners/