### PR TITLE
Don't Redeclare 'errno'

### DIFF
--- a/lib/ecl/fortio.c
+++ b/lib/ecl/fortio.c
@@ -30,8 +30,6 @@
 
 #define FORTIO_ID  345116
 
-extern int errno;
-
 /**
 The fortio struct is implemented to handle fortran io. The problem is
 that when a Fortran program writes unformatted data to file in a


### PR DESCRIPTION
Not all platforms implement 'errno' as a global object.  Since we already include `<errno.h>`, there is no need to explicitly declare the object itself.  This, for instance, fixes a linkage problem when
building ResInsight on Windows (MSVC) in the context of ResInsight:
```
2>c:\users\bska\documents\projects\software\repos\opm\resinsight\thirdparty\ert\lib\ecl\fortio.c(33): warning C4273: '_errno': inconsistent dll linkage
```

**Approach**
_Remove a potentially conflicting object declaration_