### PR TITLE
Use c++ TestArea

### DIFF
--- a/lib/ecl/tests/ecl_file.cpp
+++ b/lib/ecl/tests/ecl_file.cpp
@@ -31,7 +31,7 @@
 #include <ert/ecl/ecl_endian_flip.hpp>
 
 void test_writable(size_t data_size) {
-  test_work_area_type * work_area = test_work_area_alloc("ecl_file_writable");
+  ecl::util::TestArea ta("file_writable");
   const char * data_file_name = "test_file";
 
   ecl_kw_type * kw = ecl_kw_alloc("TEST_KW", data_size, ECL_INT);
@@ -54,11 +54,10 @@ void test_writable(size_t data_size) {
   }
 
   ecl_kw_free(kw);
-  test_work_area_free( work_area );
 }
 
 void test_truncated() {
-  test_work_area_type * work_area = test_work_area_alloc("ecl_file_truncated" );
+  ecl::util::TestArea ta("truncate_file");
   int num_kw;
   {
     ecl_grid_type * grid = ecl_grid_alloc_rectangular(20,20,20,1,1,1,NULL);
@@ -84,7 +83,6 @@ void test_truncated() {
     test_assert_true( ecl_file_get_size( ecl_file) < num_kw );
     ecl_file_close( ecl_file );
   }
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/ecl/tests/ecl_file_equinor.cpp
+++ b/lib/ecl/tests/ecl_file_equinor.cpp
@@ -108,10 +108,10 @@ void test_close_stream1(const char * src_file , const char * target_file ) {
 
 
 void test_writable(const char * src_file ) {
-  test_work_area_type * work_area = test_work_area_alloc("ecl_file_writable" );
+  ecl::util::TestArea ta("file_writable");
   char * fname = util_split_alloc_filename( src_file );
 
-  test_work_area_copy_file( work_area , src_file );
+  ta.copy_file(src_file);
   {
     test_flags( fname );
     ecl_file_type * ecl_file = ecl_file_open( fname , ECL_FILE_WRITABLE);
@@ -127,7 +127,6 @@ void test_writable(const char * src_file ) {
     swat = ecl_file_iget_named_kw( ecl_file , "SWAT" , 0 );
     test_assert_true( util_double_approx_equal( ecl_kw_iget_float( swat , 0 ) , 1000 ));
   }
-  test_work_area_free( work_area );
 }
 
 
@@ -138,16 +137,15 @@ int main( int argc , char ** argv) {
   const char * target_file = argv[2];
 
   {
-    test_work_area_type * work_area = test_work_area_alloc("ecl_file");
+    ecl::util::TestArea ta("file_equinor");
 
-    test_work_area_copy_file( work_area , src_file );
+    ta.copy_file( src_file );
     test_loadall(src_file , target_file );
 
     test_close_stream1( src_file , target_file);
     test_close_stream2( src_file , target_file);
     test_writable( src_file );
 
-    test_work_area_free( work_area );
   }
   exit(0);
 }

--- a/lib/ecl/tests/ecl_file_view.cpp
+++ b/lib/ecl/tests/ecl_file_view.cpp
@@ -59,7 +59,7 @@ void test_create_file_kw() {
   test_assert_int_equal( ecl_file_kw_get_size( file_kw0 ) , 1000 );
   test_assert_true( ecl_type_is_equal( ecl_file_kw_get_data_type( file_kw0 ) , ECL_FLOAT ));
   {
-    test_work_area_type * work_area = test_work_area_alloc("file_kw");
+    ecl::util::TestArea ta("file_kw");
     {
       FILE * ostream = util_fopen("file_kw" , "w");
       ecl_file_kw_fwrite( file_kw0 , ostream );
@@ -101,7 +101,6 @@ void test_create_file_kw() {
       test_assert_NULL( ecl_file_kw_fread_alloc_multiple( istream , 10));
       fclose( istream );
     }
-    test_work_area_free( work_area );
   }
   ecl_file_kw_free( file_kw0 );
   ecl_file_kw_free( file_kw1 );

--- a/lib/ecl/tests/ecl_fmt.cpp
+++ b/lib/ecl/tests/ecl_fmt.cpp
@@ -25,18 +25,17 @@
 
 #include <ert/ecl/ecl_util.hpp>
 
-void test_content( test_work_area_type * work_area , const char * src_file , bool fmt_file ) {
-  test_work_area_install_file( work_area , src_file );
+void test_content( const ecl::util::TestArea& ta , const char * src_file , bool fmt_file ) {
+  ta.copy_file(src_file);
   {
     char * base_name;
     bool fmt;
     util_alloc_file_components( src_file , NULL , &base_name , NULL);
-    util_copy_file( src_file , base_name );
-
     test_assert_true( ecl_util_fmt_file( base_name , &fmt ));
     test_assert_bool_equal( fmt , fmt_file );
   }
 }
+
 
 
 
@@ -56,7 +55,7 @@ void test_small( ) {
 
 
 int main(int argc , char ** argv) {
-  test_work_area_type * work_area = test_work_area_alloc( "ecl_fmt");
+  ecl::util::TestArea ta("ecl_fmt");
   {
     const char * binary_file = argv[1];
     const char * text_file = argv[2];
@@ -78,10 +77,9 @@ int main(int argc , char ** argv) {
 
     test_assert_false(ecl_util_fmt_file( "TEST_DOES_NOT_EXIST" , &fmt_file ));
 
-    test_content( work_area , binary_file , false );
-    test_content( work_area , text_file , true );
+    test_content( ta , binary_file , false );
+    test_content( ta , text_file , true );
     test_small( );
   }
-  test_work_area_free( work_area );
   exit(0);
 }

--- a/lib/ecl/tests/ecl_grid_add_nnc.cpp
+++ b/lib/ecl/tests/ecl_grid_add_nnc.cpp
@@ -60,14 +60,13 @@ void simple_test() {
 
   verify_simple_nnc( grid0 );
   {
-    test_work_area_type * test_area = test_work_area_alloc("ecl_grid_nnc");
+    ecl::util::TestArea ta("simple_nnc");
     ecl_grid_type * grid1;
     ecl_grid_fwrite_EGRID2( grid0 , "TEST.EGRID" , ECL_METRIC_UNITS);
     grid1 = ecl_grid_alloc( "TEST.EGRID" );
 
     verify_simple_nnc( grid1 );
     ecl_grid_free( grid1 );
-    test_work_area_free( test_area );
   }
   ecl_grid_free( grid0 );
 }
@@ -90,14 +89,13 @@ void overwrite_test() {
 
   verify_simple_nnc( grid0 );
   {
-    test_work_area_type * test_area = test_work_area_alloc("ecl_grid_nnc");
+    ecl::util::TestArea ta("overwrite");
     ecl_grid_type * grid1;
     ecl_grid_fwrite_EGRID2( grid0 , "TEST.EGRID" , ECL_METRIC_UNITS);
     grid1 = ecl_grid_alloc( "TEST.EGRID" );
 
     verify_simple_nnc( grid1 );
     ecl_grid_free( grid1 );
-    test_work_area_free( test_area );
   }
   ecl_grid_free( grid0 );
 }
@@ -118,14 +116,13 @@ void list_test() {
 
   verify_simple_nnc( grid0 );
   {
-    test_work_area_type * test_area = test_work_area_alloc("ecl_grid_nnc");
+    ecl::util::TestArea ta("list_test");
     ecl_grid_type * grid1;
     ecl_grid_fwrite_EGRID2( grid0 , "TEST.EGRID" , ECL_METRIC_UNITS);
     grid1 = ecl_grid_alloc( "TEST.EGRID" );
 
     verify_simple_nnc( grid1 );
     ecl_grid_free( grid1 );
-    test_work_area_free( test_area );
   }
   ecl_grid_free( grid0 );
 }

--- a/lib/ecl/tests/ecl_grid_export.cpp
+++ b/lib/ecl/tests/ecl_grid_export.cpp
@@ -154,7 +154,7 @@ void export_mapaxes( const ecl_grid_type * grid , ecl_file_type * ecl_file ) {
 
 
 int main(int argc , char ** argv) {
-  test_work_area_type * work_area = test_work_area_alloc("grid_export");
+  ecl::util::TestArea ta("grid_export");
   {
     const char * test_grid = "TEST.EGRID";
     const char * grid_file;
@@ -181,5 +181,4 @@ int main(int argc , char ** argv) {
       ecl_grid_free( ecl_grid );
     }
   }
-  test_work_area_free( work_area );
 }

--- a/lib/ecl/tests/ecl_grid_ext_actnum.cpp
+++ b/lib/ecl/tests/ecl_grid_ext_actnum.cpp
@@ -12,7 +12,7 @@
 
 void test_1() {
 
-  test_work_area_type * work_area = test_work_area_alloc("ext_actnum_main_grid");
+  ecl::util::TestArea ta("test1");
   {
     const char * filename = "FILE.EGRID";
 
@@ -53,9 +53,6 @@ void test_1() {
     ecl_grid_free( grid );
 
   }
-  test_work_area_free( work_area );
-  
-
 }
 
 

--- a/lib/ecl/tests/ecl_grid_init_fwrite.cpp
+++ b/lib/ecl/tests/ecl_grid_init_fwrite.cpp
@@ -31,7 +31,7 @@
 
 
 void test_write_depth(const ecl_grid_type * grid) {
-  test_work_area_type * test_area = test_work_area_alloc("write_depth");
+  ecl::util::TestArea ta("write_depth");
   {
     fortio_type * init_file = fortio_open_writer( "INIT" , false , ECL_ENDIAN_FLIP );
     ecl_grid_fwrite_depth( grid , init_file , ECL_METRIC_UNITS);
@@ -47,12 +47,11 @@ void test_write_depth(const ecl_grid_type * grid) {
 
     ecl_file_close(init_file);
   }
-  test_work_area_free( test_area );
 }
 
 
 void test_write_dims(const ecl_grid_type * grid) {
-  test_work_area_type * test_area = test_work_area_alloc("write_dims");
+  ecl::util::TestArea ta("write_dims");
   {
     fortio_type * init_file = fortio_open_writer( "INIT" , false , ECL_ENDIAN_FLIP );
     ecl_grid_fwrite_dims( grid , init_file , ECL_METRIC_UNITS );
@@ -74,7 +73,6 @@ void test_write_dims(const ecl_grid_type * grid) {
     }
     ecl_file_close(init_file);
   }
-  test_work_area_free( test_area );
 }
 
 

--- a/lib/ecl/tests/ecl_grid_unit_system.cpp
+++ b/lib/ecl/tests/ecl_grid_unit_system.cpp
@@ -52,12 +52,10 @@ void test_GRID(const char * filename, ert_ecl_unit_enum unit_system) {
 
 
 int main(int argc, char **argv) {
-  test_work_area_type * work_area = test_work_area_alloc("grid_export");
+  ecl::util::TestArea ta("grid_unit_system");
 
   test_EGRID("METRIC.EGRID", ECL_METRIC_UNITS);
   test_EGRID("FIELD.EGRID", ECL_FIELD_UNITS);
   test_GRID("METRIC.GRID", ECL_METRIC_UNITS);
   test_GRID("FIELD.GRID", ECL_FIELD_UNITS);
-
-  test_work_area_free(work_area);
 }

--- a/lib/ecl/tests/ecl_init_file.cpp
+++ b/lib/ecl/tests/ecl_init_file.cpp
@@ -36,8 +36,8 @@ void test_write_header() {
   int ny = 10;
   int nz = 5;
 
+  ecl::util::TestArea ta("WRITE_header");
   int_vector_type * actnum = int_vector_alloc( nx*ny*nz , 1 );
-  test_work_area_type * test_area = test_work_area_alloc( "ecl_init_file" );
   time_t start_time = util_make_date_utc(15 , 12 , 2010 );
   ecl_grid_type * ecl_grid;
 
@@ -84,7 +84,6 @@ void test_write_header() {
     ecl_init_file_fwrite_header( f , ecl_grid , NULL , ECL_METRIC_UNITS, 7 , start_time );
     fortio_fclose( f );
   }
-  test_work_area_free( test_area );
 }
 
 

--- a/lib/ecl/tests/ecl_kw_fread.cpp
+++ b/lib/ecl/tests/ecl_kw_fread.cpp
@@ -45,7 +45,7 @@ void test_truncated(const char * filename , offset_type truncate_size) {
 
 
 void test_fread_alloc() {
-  test_work_area_type * work_area = test_work_area_alloc("ecl_kw_fread" );
+  ecl::util::TestArea ta("fread_alloc");
   {
     ecl_kw_type * kw1 = ecl_kw_alloc( "INT" , 100 , ECL_INT );
     int i;
@@ -74,11 +74,10 @@ void test_fread_alloc() {
     }
     ecl_kw_free( kw1 );
   }
-  test_work_area_free( work_area );
 }
 
 void test_kw_io_charlength() {
-  test_work_area_type * work_area = test_work_area_alloc("ecl_kw_io_charlength");
+  ecl::util::TestArea ta("io_charlength");
   {
     const char * KW0 = "QWERTYUI";
     const char * KW1 = "ABCDEFGHIJTTTTTTTTTTTTTTTTTTTTTTABCDEFGHIJKLMNOP";
@@ -121,7 +120,6 @@ void test_kw_io_charlength() {
     ecl_kw_free( ecl_kw_out0 );
     ecl_kw_free( ecl_kw_out1 );
   }
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/ecl/tests/ecl_kw_grdecl.cpp
+++ b/lib/ecl/tests/ecl_kw_grdecl.cpp
@@ -32,7 +32,7 @@ int main(int argc , char ** argv) {
     ecl_kw_iset_int(ecl_kw , i , i );
 
   {
-    test_work_area_type * work_area = test_work_area_alloc("ecl_kw_grdecl");
+    ecl::util::TestArea ta("kw_grdecl");
     FILE * stream = util_fopen( "FILE.grdecl" , "w");
 
     ecl_kw_fprintf_grdecl(ecl_kw , stream );
@@ -65,7 +65,6 @@ int main(int argc , char ** argv) {
       ecl_kw_free( ecl_kw2 );
     }
     fclose( stream );
-    test_work_area_free( work_area );
   }
   ecl_kw_free( ecl_kw );
 

--- a/lib/ecl/tests/ecl_nnc_geometry.cpp
+++ b/lib/ecl/tests/ecl_nnc_geometry.cpp
@@ -36,7 +36,7 @@ void test_create_empty() {
 }
 
 void test_create_simple() {
-  test_work_area_type * work_area = test_work_area_alloc("nnc-INIT");
+  ecl::util::TestArea ta("nnc_geometry");
   {
     int nx = 10;
     int ny = 10;
@@ -67,7 +67,6 @@ void test_create_simple() {
     }
     ecl_grid_free( grid0 );
   }
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/ecl/tests/ecl_rft.cpp
+++ b/lib/ecl/tests/ecl_rft.cpp
@@ -40,10 +40,9 @@ void test_rft_read_write(const char * rft_file){
     ecl_rft_node_type * old_node = ecl_rft_file_iget_node(rft, 0);
     ecl_rft_node_type * new_node = ecl_rft_node_alloc_new("DUMMY", "R", ecl_rft_node_get_date(old_node), ecl_rft_node_get_days(old_node));
     nodes[2]=new_node;
-    test_work_area_type * work_area = test_work_area_alloc("RFT_RW");
+    ecl::util::TestArea ta("rft");
 
     ecl_rft_file_update("eclipse.rft", nodes,3, ECL_METRIC_UNITS);
-    test_work_area_free(work_area);
     free(nodes);
 }
 

--- a/lib/ecl/tests/ecl_rst_file.cpp
+++ b/lib/ecl/tests/ecl_rst_file.cpp
@@ -65,7 +65,7 @@ void test_file( const char * src_file , const char * target_file , int report_st
 
 
 void test_Xfile() {
-  test_work_area_type * work_area = test_work_area_alloc("rst-file");
+  ecl::util::TestArea ta("xfile");
   {
     fortio_type * f = fortio_open_writer( "TEST.X0010" , false , ECL_ENDIAN_FLIP);
 
@@ -80,13 +80,12 @@ void test_Xfile() {
     fortio_fclose( f );
   }
   test_file( "TEST.X0010" , "FILE.X0010" , 10 , 0 );
-  test_work_area_free( work_area );
 }
 
 
 
 void test_UNRST0() {
-  test_work_area_type * work_area = test_work_area_alloc("rst-file");
+  ecl::util::TestArea ta("rst-file");
   offset_type pos10;
   offset_type pos20;
   offset_type pos_end;
@@ -118,12 +117,11 @@ void test_UNRST0() {
   test_file( "TEST.UNRST" , "FILE.UNRST" , 15 , pos20 );
   test_file( "TEST.UNRST" , "FILE.UNRST" , 20 , pos20 );
   test_file( "TEST.UNRST" , "FILE.UNRST" , 25 , pos_end );
-  test_work_area_free( work_area );
 }
 
 
 void test_UNRST1() {
-  test_work_area_type * work_area = test_work_area_alloc("rst-file");
+  ecl::util::TestArea ta("rst-file");
   offset_type pos5;
   offset_type pos10;
   offset_type pos20;
@@ -158,7 +156,6 @@ void test_UNRST1() {
   test_file( "TEST.UNRST" , "FILE.UNRST" , 15 , pos20 );
   test_file( "TEST.UNRST" , "FILE.UNRST" , 20 , pos20 );
   test_file( "TEST.UNRST" , "FILE.UNRST" , 25 , pos_end );
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
+++ b/lib/ecl/tests/ecl_sum_data_intermediate_test.cpp
@@ -260,7 +260,7 @@ void verify_CASE4() {
 
 
 void write_CASE4(bool unified) {
-  test_work_area_type * work_area = test_work_area_alloc("CASE4");
+  ecl::util::TestArea ta("case4");
   write_CASE3(unified);
   {
     ecl_file_type * sum_file    = ecl_file_open("CASE3.UNSMRY", 0);
@@ -309,7 +309,6 @@ void write_CASE4(bool unified) {
     ecl_file_close(sum_file);
     verify_CASE4();
   }
-  test_work_area_free(work_area);
 }
 
 int main() {

--- a/lib/ecl/tests/ecl_sum_writer.cpp
+++ b/lib/ecl/tests/ecl_sum_writer.cpp
@@ -100,7 +100,6 @@ void test_write_read( ) {
   int num_ministep = 10;
   double ministep_length = 86400; // Seconds - numerical value chosen to avoid rounding problems when converting between seconds and days.
   {
-    //test_work_area_type * work_area = test_work_area_alloc("sum/write");
     ecl_sum_type * ecl_sum;
 
     auto seconds = write_summary( name , start_time , nx , ny , nz , num_dates , num_ministep , ministep_length);
@@ -143,8 +142,7 @@ void test_write_read( ) {
 
 
 void test_ecl_sum_alloc_restart_writer() {
-
-   test_work_area_type * work_area = test_work_area_alloc("sum_write_restart");
+   ecl::util::TestArea ta("sum_write_restart");
    {
       const char * name1 = "CASE1";
       const char * name2 = "CASE2";
@@ -181,7 +179,6 @@ void test_ecl_sum_alloc_restart_writer() {
       ecl_file_close(restart_file);
 
    }
-   test_work_area_free( work_area );
 }
 
 
@@ -193,7 +190,7 @@ void test_long_restart_names() {
       strcat(restart_case, s);
    }
    const char * name = "THE_CASE";
-   test_work_area_type * work_area = test_work_area_alloc("sum_write_restart_long_name");
+   ecl::util::TestArea ta("suM_write_restart_long_name");
    {
        int restart_step = 77;
        time_t start_time = util_make_date_utc( 1,1,2010 );
@@ -221,9 +218,6 @@ void test_long_restart_names() {
          ecl_smspec_free( smspec);
        }
    }
-
-   test_work_area_free( work_area );
-
 }
 
 int main( int argc , char ** argv) {

--- a/lib/ecl/tests/ecl_unsmry_loader_test.cpp
+++ b/lib/ecl/tests/ecl_unsmry_loader_test.cpp
@@ -36,7 +36,7 @@ ecl_sum_type * write_ecl_sum() {
 }
 
 void test_load() {
-  test_work_area_type * work_area = test_work_area_alloc("unsmry_loader");
+  ecl::util::TestArea ta("ecl_sum_loader");
   ecl_sum_type * ecl_sum = write_ecl_sum();
   test_assert_true( util_file_exists("CASE.SMSPEC") );
   test_assert_true( util_file_exists("CASE.UNSMRY") );
@@ -52,7 +52,6 @@ void test_load() {
 
   delete loader;
   ecl_sum_free(ecl_sum);
-  test_work_area_free(work_area);
 }
 
 int main() {

--- a/lib/ecl/tests/ecl_util_filenames.cpp
+++ b/lib/ecl/tests/ecl_util_filenames.cpp
@@ -40,7 +40,7 @@ void test_filename_case() {
 
 
 void test_file_list() {
-  test_work_area_type * work_area = test_work_area_alloc("RESTART_FILES");
+  ecl::util::TestArea ta("file_list");
   stringlist_type * s = stringlist_alloc_new();
 
   for (int i = 0; i < 10; i += 2) {
@@ -109,7 +109,6 @@ void test_file_list() {
   test_assert_int_equal(stringlist_get_size(s), 10);
 
   stringlist_free(s);
-  test_work_area_free(work_area);
 }
 
 

--- a/lib/ecl/tests/ecl_util_path_access.cpp
+++ b/lib/ecl/tests/ecl_util_path_access.cpp
@@ -27,7 +27,7 @@
 
 
 void test_relative_access() {
-  test_work_area_type * work_area = test_work_area_alloc("access");
+  ecl::util::TestArea ta("ecl_access");
   test_assert_false( ecl_util_path_access("No/directory/does/not/exist"));
 
   util_make_path("path");
@@ -44,7 +44,6 @@ void test_relative_access() {
   test_assert_false( ecl_util_path_access("path/file"));
 
   test_assert_true( ecl_util_path_access("ECLIPSE_CASE"));
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/ecl/tests/eclxx_fortio.cpp
+++ b/lib/ecl/tests/eclxx_fortio.cpp
@@ -28,7 +28,7 @@
 
 
 void test_open() {
-    test_work_area_type * work_area = test_work_area_alloc("FORTIO");
+    ecl::util::TestArea ta("fortioxx");
     ERT::FortIO fortio;
     fortio.open( "new_file" , std::fstream::out );
 
@@ -67,12 +67,11 @@ void test_open() {
     }
     test_assert_false( fortio.ftruncate( 0 ));
     fortio.close();
-    test_work_area_free(work_area);
 }
 
 
 void test_fortio() {
-    test_work_area_type * work_area = test_work_area_alloc("FORTIO");
+    ecl::util::TestArea ta("FORTIO");
     ERT::FortIO fortio("new_file" , std::fstream::out );
     {
         std::vector<int> data;
@@ -97,12 +96,11 @@ void test_fortio() {
     fortio.close();
 
     test_assert_throw( ERT::FortIO fortio("file/does/not/exists" , std::fstream::in) , std::invalid_argument );
-    test_work_area_free(work_area);
 }
 
 
 void test_fortio_kw() {
-    test_work_area_type * work_area = test_work_area_alloc("FORTIO");
+    ecl::util::TestArea ta("fortio_kw");
     std::vector< int > vec( 1000 );
 
     for (size_t i =0 ; i < vec.size(); i++)
@@ -128,7 +126,6 @@ void test_fortio_kw() {
         test_assert_throw( ERT::EclKW<float>::load(fortio) , std::invalid_argument );
         fortio.close();
     }
-    test_work_area_free(work_area);
 }
 
 

--- a/lib/ecl/tests/eclxx_kw.cpp
+++ b/lib/ecl/tests/eclxx_kw.cpp
@@ -170,7 +170,7 @@ void test_read_write() {
     std::vector<std::string> s_data = {"S1", "S2", "S3"};
 
     {
-        test_work_area_type * work_area = test_work_area_alloc("READ_WRITE");
+        ecl::util::TestArea ta("kw-read-write");
         {
           ERT::FortIO f("test_file", std::ios_base::out);
           ERT::write_kw(f, "DOUBLE", d_data);
@@ -208,7 +208,6 @@ void test_read_write() {
           }
 
           ecl_file_close(f);
-          test_work_area_free(work_area);
         }
     }
 }

--- a/lib/ecl/tests/test_ecl_file_index.cpp
+++ b/lib/ecl/tests/test_ecl_file_index.cpp
@@ -34,7 +34,7 @@ void test_load_nonexisting_file() {
 
 void test_create_and_load_index_file() {
 
-   test_work_area_type * work_area = test_work_area_alloc("ecl_file_index_testing");
+   ecl::util::TestArea ta("Load_index");
    {
       const char * file_name = "initial_data_file";
       const char * index_file_name = "index_file";
@@ -98,7 +98,6 @@ void test_create_and_load_index_file() {
       ecl_kw_free(kw2);
       ecl_file_close( ecl_file_index );
    }
-   test_work_area_free( work_area );
 }
 
 

--- a/lib/ecl/tests/test_ecl_nnc_data.cpp
+++ b/lib/ecl/tests/test_ecl_nnc_data.cpp
@@ -34,7 +34,7 @@
 
 
 void test_alloc_global_only(bool data_in_file) {
-   test_work_area_type * work_area = test_work_area_alloc("nnc-INIT");
+   ecl::util::TestArea ta("nnc-INIT");
    {
       int nx = 10;
       int ny = 10;
@@ -90,7 +90,6 @@ void test_alloc_global_only(bool data_in_file) {
       }
       ecl_grid_free( grid0 );
    }
-   test_work_area_free( work_area );
 }
 
 

--- a/lib/ecl/tests/test_transactions.cpp
+++ b/lib/ecl/tests/test_transactions.cpp
@@ -38,7 +38,7 @@
 
 void test_transaction() {
 
-  test_work_area_type * work_area = test_work_area_alloc("ecl_file_index_testing");
+  ecl::util::TestArea ta("index_testing");
   {
      const char * file_name = "data_file";
      fortio_type * fortio = fortio_open_writer(file_name, false, ECL_ENDIAN_FLIP);
@@ -101,7 +101,6 @@ void test_transaction() {
      ecl_file_close(file);
 
    }
-   test_work_area_free( work_area );
 }
 
 

--- a/lib/util/tests/ert_util_chdir.cpp
+++ b/lib/util/tests/ert_util_chdir.cpp
@@ -24,8 +24,8 @@
 
 
 void test_chdir() {
-  test_work_area_type * work_area = test_work_area_alloc("test-area");
-  const char * cwd = test_work_area_get_cwd( work_area );
+  ecl::util::TestArea ta("chdir");
+  const char * cwd = ta.test_cwd().c_str();
 
   test_assert_false( util_chdir_file( "/file/does/not/exist"));
   test_assert_false( util_chdir_file( cwd ));
@@ -35,7 +35,6 @@ void test_chdir() {
   }
   test_assert_true( util_chdir_file( "path/FILE" ));
   test_assert_string_equal( util_alloc_cwd() , util_alloc_filename( cwd, "path", NULL));
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/util/tests/ert_util_copy_file.cpp
+++ b/lib/util/tests/ert_util_copy_file.cpp
@@ -36,7 +36,7 @@ void test_copy_file( const char * executable ) {
 
   mode0 = stat_buf.st_mode;
   {
-    test_work_area_type * test_area = test_work_area_alloc( "executable-copy" );
+    ecl::util::TestArea ta("copy_file");
 
     util_copy_file( executable , "test.x");
     test_assert_true( util_file_exists( "test.x" ));
@@ -44,7 +44,6 @@ void test_copy_file( const char * executable ) {
     mode1 = stat_buf.st_mode;
 
     test_assert_true( mode0 == mode1 );
-    test_work_area_free( test_area );
   }
 }
 

--- a/lib/util/tests/ert_util_mkdir_p.cpp
+++ b/lib/util/tests/ert_util_mkdir_p.cpp
@@ -24,7 +24,7 @@
 
 
 int main(int argc , char ** argv) {
-  test_work_area_type * work_area = test_work_area_alloc("Test_area");
+  ecl::util::TestArea ta("mkdir");
 
   // Regular use
   test_assert_true( util_mkdir_p("some/path/with/many/levels"));
@@ -45,6 +45,5 @@ int main(int argc , char ** argv) {
   chmod("read_only", 0555);
   test_assert_false(util_mkdir_p("read_only/no/not/this"));
 
-  test_work_area_free(work_area);
   exit(0);
 }

--- a/lib/util/tests/ert_util_normal_path.cpp
+++ b/lib/util/tests/ert_util_normal_path.cpp
@@ -32,7 +32,7 @@ void test_path(const char * input_path, const char * expected_path) {
 
 
 void test_relative() {
-  test_work_area_type * work_area = test_work_area_alloc("Work");
+  ecl::util::TestArea ta("relative_path");
   util_make_path("level0/level1/level2");
 
   test_path( "level0/level1/../", "level0");
@@ -48,11 +48,10 @@ void test_relative() {
   util_chdir("level0/level1");
   test_path("../../level0/level1/level2/../file.txt" , "file.txt");
   test_path("../../level0/level1/level2/../" , "");
-  test_work_area_free( work_area );
 }
 
 void test_beyond_root() {
-  test_work_area_type * work_area = test_work_area_alloc("Work");
+  ecl::util::TestArea("beyond_root");
   char * cwd = util_alloc_cwd( );
   char * backref_cwd1 = util_alloc_sprintf("../../../../../../../../../../../%s" , cwd );
   char * backref_cwd2 = util_alloc_sprintf("/../../../../../../../../../../../%s" , cwd );
@@ -61,7 +60,6 @@ void test_beyond_root() {
   free( backref_cwd1 );
   free( backref_cwd2 );
   free( cwd );
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/util/tests/ert_util_spawn.cpp
+++ b/lib/util/tests/ert_util_spawn.cpp
@@ -59,7 +59,7 @@ bool check_script(const char* script) {
 }
 
 void test_spawn_no_redirect() {
-  test_work_area_type * test_area = test_work_area_alloc("spawn1");
+  ecl::util::TestArea ta("spawn1");
   {
     int status;
     make_script("script" , stdout_msg , stderr_msg);
@@ -77,7 +77,6 @@ void test_spawn_no_redirect() {
       test_assert_int_equal( status , 0 );
     }
   }
-  test_work_area_free( test_area );
 }
 
 
@@ -136,7 +135,7 @@ void * test_spawn_redirect__( const char * path ) {
 
 
 void test_spawn_redirect() {
-  test_work_area_type * test_area = test_work_area_alloc("spawn1");
+  ecl::util::TestArea ta("test_redirect");
   {
     make_script("script" , stdout_msg , stderr_msg);
     util_addmode_if_owner( "script" , S_IRUSR + S_IWUSR + S_IXUSR + S_IRGRP + S_IWGRP + S_IXGRP + S_IROTH + S_IXOTH);  /* u:rwx  g:rwx  o:rx */
@@ -144,14 +143,13 @@ void test_spawn_redirect() {
 
     test_spawn_redirect__( NULL );
   }
-  test_work_area_free( test_area );
 }
 
 void test_spawn_redirect_threaded() {
    const int num = 128;
 
    // Generate the scripts on disk first
-   test_work_area_type * test_area = test_work_area_alloc("spawn1_threaded");
+   ecl::util::TestArea("spawn1_threaded");
    int * path_codes = (int *)util_calloc(num, sizeof *path_codes);
    stringlist_type * script_fullpaths = stringlist_alloc_new();
    for (int i=0; i < num; i++) {
@@ -180,7 +178,6 @@ void test_spawn_redirect_threaded() {
 
    stringlist_free(script_fullpaths);
    free(path_codes);
-   test_work_area_free( test_area );
 }
 
 

--- a/lib/util/tests/ert_util_stringlist_test.cpp
+++ b/lib/util/tests/ert_util_stringlist_test.cpp
@@ -347,7 +347,7 @@ bool not_FILE_predicate(const char * name, const void * arg) {
 
 
 void test_predicate_matching() {
-  test_work_area_type * work_area = test_work_area_alloc("predicate_test");
+  ecl::util::TestArea ta("stringlist");
   stringlist_type * s = stringlist_alloc_new();
   stringlist_append_copy(s, "s");
   stringlist_select_files(s, "does/not/exist", NULL, NULL);
@@ -358,7 +358,7 @@ void test_predicate_matching() {
     FILE * f = util_fopen("FILE.txt", "w");
     fclose(f);
   }
-  stringlist_select_files(s , test_work_area_get_cwd(work_area), NULL, NULL);
+  stringlist_select_files(s , ta.test_cwd().c_str(), NULL, NULL);
   test_assert_int_equal(1, stringlist_get_size(s));
   {
     char * exp = util_alloc_abs_path("FILE.txt");
@@ -370,7 +370,7 @@ void test_predicate_matching() {
   test_assert_int_equal(1, stringlist_get_size(s));
   test_assert_string_equal( "FILE.txt", stringlist_iget(s, 0));
 
-  stringlist_select_files(s , test_work_area_get_cwd(work_area), FILE_predicate, NULL);
+  stringlist_select_files(s , ta.test_cwd().c_str(), FILE_predicate, NULL);
   test_assert_int_equal(1, stringlist_get_size(s));
   {
     char * exp = util_alloc_abs_path("FILE.txt");
@@ -378,11 +378,10 @@ void test_predicate_matching() {
     free(exp);
   }
 
-  stringlist_select_files(s , test_work_area_get_cwd(work_area), not_FILE_predicate, NULL);
+  stringlist_select_files(s , ta.test_cwd().c_str(), not_FILE_predicate, NULL);
   test_assert_int_equal(0, stringlist_get_size(s));
 
   stringlist_free(s);
-  test_work_area_free(work_area);
 }
 
 


### PR DESCRIPTION
**Issue**
This PR is a small followup to #562. In #562 the testarea implementation was based on C++, with a C api for Python and legacy. In this PR all the C++ tests are converted to use the C++ `TestArea` implementation - the main gain of this is that manual calls to `test_work_area_free( )` are removed in favor of C++ automatic destruction. A small step - hopefully in a favorable direction.

**Approach**
The PR consists of replacing many:
```C++
test_work_area_type * work_area = test_work_area_alloc("test_name");
....
test_work_area_free( work_area );
```

with the C++ variety:

```
ecl::util::TestArea ta("test_name");
...
```


