### PR TITLE
WIP: Prepare to replace @TYPE@_vector with std::vector<T>

### DIFF
--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -6735,8 +6735,8 @@ void ecl_grid_reset_actnum( ecl_grid_type * grid , const int * actnum ) {
 
 static void  ecl_grid_fwrite_self_nnc( const ecl_grid_type * grid , fortio_type * fortio ) {
   const int default_index = 1;
-  int_vector_type * g1 = int_vector_alloc(0 , default_index );
-  int_vector_type * g2 = int_vector_alloc(0 , default_index );
+  std::vector<int> g1;
+  std::vector<int> g2;
   int g;
 
   for (g=0; g < ecl_grid_get_global_size(grid); g++) {
@@ -6747,15 +6747,22 @@ static void  ecl_grid_fwrite_self_nnc( const ecl_grid_type * grid , fortio_type 
       int i;
       for (i = 0; i < nnc_vector_get_size( nnc_vector ); i++) {
         int nnc_index = nnc_vector_iget_nnc_index( nnc_vector , i );
-        int_vector_iset( g1 , nnc_index , 1 + g );
-        int_vector_iset( g2 , nnc_index , 1 + nnc_vector_iget_grid_index( nnc_vector , i ));
+
+        if (g1.size() <= static_cast<std::size_t>(nnc_index))
+          g1.resize(nnc_index + 1, default_index);
+        g1[nnc_index] = 1 + g;
+
+        if (g2.size() <= static_cast<std::size_t>(nnc_index))
+          g2.resize(nnc_index + 1, default_index);
+        g2[nnc_index] = 1 + nnc_vector_iget_grid_index(nnc_vector, i);
+
       }
     }
   }
   {
-    int num_nnc = int_vector_size( g1 );
-    ecl_kw_type * nnc1_kw = ecl_kw_alloc_new_shared( NNC1_KW , num_nnc , ECL_INT , int_vector_get_ptr( g1 ));
-    ecl_kw_type * nnc2_kw = ecl_kw_alloc_new_shared( NNC2_KW , num_nnc , ECL_INT , int_vector_get_ptr( g2 ));
+    int num_nnc = g1.size();
+    ecl_kw_type * nnc1_kw = ecl_kw_alloc_new_shared( NNC1_KW , num_nnc , ECL_INT , g1.data() );
+    ecl_kw_type * nnc2_kw = ecl_kw_alloc_new_shared( NNC2_KW , num_nnc , ECL_INT , g2.data() );
     ecl_kw_type * nnchead_kw = ecl_kw_alloc( NNCHEAD_KW , NNCHEAD_SIZE , ECL_INT);
 
     ecl_kw_scalar_set_int( nnchead_kw , 0 );
@@ -6770,9 +6777,6 @@ static void  ecl_grid_fwrite_self_nnc( const ecl_grid_type * grid , fortio_type 
     ecl_kw_free( nnc2_kw );
     ecl_kw_free( nnc1_kw );
   }
-
-  int_vector_free( g1 );
-  int_vector_free( g2 );
 }
 
 

--- a/lib/ecl/ecl_sum_data.cpp
+++ b/lib/ecl/ecl_sum_data.cpp
@@ -899,6 +899,7 @@ void ecl_sum_data_fwrite_interp_csv_line(const ecl_sum_data_type * data, time_t 
 void ecl_sum_data_get_interp_vector( const ecl_sum_data_type * data , time_t sim_time, const ecl_sum_vector_type * keylist, double_vector_type * results){
   int num_keywords = ecl_sum_vector_get_size(keylist);
   double weight1, weight2;
+  double default_value = double_vector_get_default(results);
   int    time_index1, time_index2;
 
   ecl_sum_data_init_interp_from_sim_time(data, sim_time, &time_index1, &time_index2, &weight1, &weight2);
@@ -908,8 +909,9 @@ void ecl_sum_data_get_interp_vector( const ecl_sum_data_type * data , time_t sim
       int params_index = ecl_sum_vector_iget_param_index(keylist, i);
       bool is_rate = ecl_sum_vector_iget_is_rate(keylist, i);
       double value = ecl_sum_data_vector_iget( data, sim_time, params_index, is_rate, time_index1, time_index2, weight1, weight2);
-      double_vector_iset( results, i , value );
-    }
+      double_vector_append( results, value);
+    } else
+      double_vector_append( results, default_value);
   }
 }
 

--- a/lib/util/string_util.cpp
+++ b/lib/util/string_util.cpp
@@ -179,6 +179,9 @@ bool string_util_update_active_mask( const char * range_string , bool_vector_typ
   int i;
   int_vector_type * sscanf_active = string_util_sscanf_alloc_active_list( range_string );
   if (sscanf_active) {
+    int new_size = util_int_max( int_vector_get_max(sscanf_active) + 1, bool_vector_size( active_mask ));
+    bool_vector_resize( active_mask, new_size, false);
+
     for (i=0; i < int_vector_size( sscanf_active ); i++)
       bool_vector_iset( active_mask , int_vector_iget(sscanf_active , i) , true );
 

--- a/lib/util/tests/ert_util_type_vector_functions.cpp
+++ b/lib/util/tests/ert_util_type_vector_functions.cpp
@@ -48,7 +48,7 @@ void test_index_list() {
 
 
 void test_mask() {
-  bool_vector_type * mask = bool_vector_alloc(0 , false);
+  bool_vector_type * mask = bool_vector_alloc(21 , false);
 
   bool_vector_iset(mask , 10, true);
   bool_vector_iset(mask , 15, true);
@@ -70,7 +70,7 @@ void test_mask() {
 
 void test_active_index_list() {
   int default_value = -1;
-  bool_vector_type * mask = bool_vector_alloc(0 , false);
+  bool_vector_type * mask = bool_vector_alloc(21 , false);
 
   bool_vector_iset(mask , 10, true);
   bool_vector_iset(mask , 15, true);

--- a/lib/util/type_vector_functions.cpp
+++ b/lib/util/type_vector_functions.cpp
@@ -53,10 +53,11 @@ int_vector_type * bool_vector_alloc_active_index_list(const bool_vector_type * m
 
 bool_vector_type * int_vector_alloc_mask( const int_vector_type * active_list ) {
   bool_vector_type * mask = bool_vector_alloc( 0 , false );
-  int i;
-  for (i=0; i < int_vector_size( active_list ); i++)
-    bool_vector_iset( mask , int_vector_iget( active_list , i) , true );
-
+  if (int_vector_size(active_list) > 0) {
+    bool_vector_resize( mask, int_vector_get_max( active_list ) + 1, false);
+    for (int i=0; i < int_vector_size( active_list ); i++)
+      bool_vector_iset( mask , int_vector_iget( active_list , i) , true );
+  }
   return mask;
 }
 

--- a/lib/util/vector_template.cpp
+++ b/lib/util/vector_template.cpp
@@ -913,16 +913,16 @@ bool @TYPE@_vector_init_linear(@TYPE@_vector_type * vector , @TYPE@ start_value,
     return false;
 
   @TYPE@_vector_reset( vector );
-  @TYPE@_vector_iset( vector, 0 , start_value);
+  @TYPE@_vector_append( vector, start_value);
   {
     double slope = (end_value - start_value) / (num_values - 1);
 
     for (int i=1; i < num_values - 1; i++) {
       @TYPE@ value = (@TYPE@) start_value + slope*i;
-      @TYPE@_vector_iset(vector, i, value);
+      @TYPE@_vector_append(vector, value);
     }
   }
-  @TYPE@_vector_iset( vector, num_values - 1, end_value);
+  @TYPE@_vector_append( vector, end_value);
   return true;
 }
 

--- a/lib/util/vector_template.cpp
+++ b/lib/util/vector_template.cpp
@@ -631,6 +631,9 @@ void @TYPE@_vector_iset(@TYPE@_vector_type * vector , int index , @TYPE@ value) 
         for (i=vector->size; i < index; i++)
           vector->data[i] = vector->default_value;
         vector->size = index + 1;
+        /*
+          util_abort("%s: tried to grow vector from iset() \n",__func__);
+        */
       }
     }
   }

--- a/python/tests/util_tests/test_vectors.py
+++ b/python/tests/util_tests/test_vectors.py
@@ -63,7 +63,7 @@ class UtilTest(TestCase):
 
 
     def test_double_vector(self):
-        v = DoubleVector()
+        v = DoubleVector(initial_size=13)
 
         v[0] = 77.25
         v[1] = 123.25
@@ -80,6 +80,7 @@ class UtilTest(TestCase):
         self.assertEqual(len(v), 0)
 
         v.clear()
+        v = DoubleVector(initial_size = 4)
 
         v[0] = 0.1
         v[1] = 0.2
@@ -102,6 +103,7 @@ class UtilTest(TestCase):
         v.clear()
         v.setDefault(0.75)
         self.assertEqual(v.getDefault(), 0.75)
+        v = DoubleVector(initial_size = 3, default_value = 0.75)
         v[2] = 0.0
         self.assertEqual(v[1], 0.75)
 
@@ -152,23 +154,13 @@ class UtilTest(TestCase):
 
     def test_repr(self):
         primes = [2,3,5,7,11,13,17,19]
-        b = BoolVector()
+        b = BoolVector(initial_size = max(max(primes) + 1, 31))
         for i in primes:
             b[i] = True
-        pfx = 'BoolVector(size = 20, content = "00110101000101000101")'
-        self.assertEqual(pfx, repr(b)[:len(pfx)])
         b[30] = True
         pfx = 'BoolVector(size = 31, content = "001101010...00000001")'
         self.assertEqual(pfx, repr(b)[:len(pfx)])
 
-
-    def test_bool_vector(self):
-        b = BoolVector()
-        b.setDefault(True)
-
-        b[4] = False
-
-        self.assertEqual(list(b), [True, True, True, True, False])
 
     def test_activeList(self):
         active_list = IntVector.active_list("1,10,100-105")
@@ -192,7 +184,7 @@ class UtilTest(TestCase):
             self.assertEqual(v1, v2)
 
     def test_contains_int(self):
-        iv = IntVector()
+        iv = IntVector(initial_size = 4)
         iv[0] = 1
         iv[1] = 10
         iv[2] = 100
@@ -331,7 +323,7 @@ class UtilTest(TestCase):
 #---
 
     def test_div(self):
-        v = IntVector()
+        v = IntVector(initial_size = 3)
         v[0] = 100
         v[1] = 10
         v[2] = 1
@@ -339,11 +331,6 @@ class UtilTest(TestCase):
 
         self.assertEqual(list(v), [10, 1, 0])
 
-    def test_true(self):
-        iv = IntVector()
-        self.assertFalse(iv)  # Will invoke the __len__ function; could override with __nonzero__
-        iv[0] = 1
-        self.assertTrue(iv)
 
     def test_time_vector(self):
         time_vector = TimeVector()
@@ -354,7 +341,8 @@ class UtilTest(TestCase):
         time_vector.setDefault(time2)
 
         time_vector.append(time1)
-        time_vector[2] = time2
+        time_vector.append(time2)
+        time_vector.append(time2)
 
         self.assertEqual(time_vector[0], time1)
         self.assertEqual(time_vector[1], time2)
@@ -475,7 +463,7 @@ class UtilTest(TestCase):
         trange = TimeVector.createRegular(start, datetime.date(2050, 1, 1), "1Y")
 
     def test_asList(self):
-        v = IntVector()
+        v = IntVector(initial_size=3)
         v[0] = 100
         v[1] = 10
         v[2] = 1
@@ -486,22 +474,18 @@ class UtilTest(TestCase):
     def test_true_false(self):
         v = IntVector(default_value=77)
         self.assertFalse(v)
-        v[10] = 77
-        self.assertTrue(v)
 
-        v = DoubleVector(default_value=77)
-        self.assertFalse(v)
-        v[10] = 77
+        v = IntVector(initial_size = 10, default_value=77)
         self.assertTrue(v)
 
     def test_count_equal(self):
-        v = IntVector(default_value=77)
+        v = IntVector(initial_size = 21, default_value=77)
         v[0] = 1
         v[10] = 1
         v[20] = 1
         self.assertEqual(v.countEqual(1), 3)
 
-        v = DoubleVector(default_value=77)
+        v = DoubleVector(initial_size = 21, default_value=77)
         v[0] = 1
         v[10] = 1
         v[20] = 1
@@ -524,7 +508,7 @@ class UtilTest(TestCase):
             self.assertEqual(a, b)
 
     def test_range(self):
-        v = IntVector()
+        v = IntVector(initial_size = 11)
         v[10] = 99
 
         with self.assertRaises(ValueError):
@@ -567,10 +551,10 @@ class UtilTest(TestCase):
             self.assertEqual( d[i] , i*0.10)
 
     def test_equal(self):
-        v1 = IntVector()
+        v1 = IntVector(initial_size = 4)
         v1[3] = 99
 
-        v2 = IntVector()
+        v2 = IntVector(initial_size = 4)
         self.assertNotEqual( v1,v2 )
         v2[3] = 99
         self.assertEqual(v1,v2)


### PR DESCRIPTION
**Issue**
The libecl codebase has home-made vector which has some familiarity with `std::vector<T>`. The most important difference is what happens when out of bounds indices are accessed; for `std::vector<T>` accessing out of bounds indices is a bug and will result in undefined behavior. The  `@TYPE@_vector` is created *with* a default value, reading out of bounds will return the default value and writing to out of bounds values will automatically grow the vector.

**Approach**
For this work I have just added `util_abort()` call (not committed) where the automatic growth is invoked, and then rewritten the failing code. 

Long way to go!

