### PR TITLE
Bug in smspec_node initialization for writer

### DIFF
--- a/lib/ecl/ecl_smspec.cpp
+++ b/lib/ecl/ecl_smspec.cpp
@@ -928,7 +928,7 @@ static const ecl::smspec_node * ecl_smspec_insert_node(ecl_smspec_type * ecl_sms
   ecl_smspec_install_gen_keys( ecl_smspec, *smspec_node.get() );
   ecl_smspec_install_special_keys( ecl_smspec, *smspec_node.get() );
 
-  if (smspec_node_need_nums( &smspec_node ))
+  if (smspec_node->need_nums())
     ecl_smspec->need_nums = true;
 
   ecl_smspec->smspec_nodes.push_back(std::move(smspec_node));

--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -923,6 +923,7 @@ smspec_node::smspec_node( int param_index_,
   this->total_variable = smspec_node_identify_total(this->keyword.c_str(), this->var_type);
   this->historical = (this->keyword.back() == 'H');
   this->lgr_name = lgr_;
+  this->num = nums_unused;
 
   switch (this->var_type) {
   case(ECL_SMSPEC_LOCAL_WELL_VAR):


### PR DESCRIPTION
**Issue**
Resolves #587

**Approach**
The valgrind issue reported in #587 is not a false positive; the function `smspec_node_need_nums()` was called incorrectly.
