### PR TITLE
#596 Output mapaxes transform if available even if use_mapaxes is false

### DIFF
--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -6949,7 +6949,7 @@ void ecl_grid_fprintf_grdecl2(ecl_grid_type * grid , FILE * stream , ert_ecl_uni
     fprintf(stream , "\n");
   }
 
-  if (grid->use_mapaxes) {
+  if (grid->mapaxes != NULL) {
     ecl_kw_type * mapaxes_kw = ecl_grid_alloc_mapaxes_kw( grid );
     ecl_kw_fprintf_grdecl( mapaxes_kw , stream );
     ecl_kw_free( mapaxes_kw );


### PR DESCRIPTION
**Issue**
Resolves #596

**Approach**
Outputs mapaxes into file even if use_mapaxes == false as long as the mapaxes pointer is not NULL.
