### PR TITLE
When creating a grid with external actnum the in file ACTNUM is ignored

### DIFF
--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -3022,23 +3022,19 @@ static ecl_grid_type * ecl_grid_alloc_EGRID__( ecl_grid_type * main_grid , const
     eclipse_version = main_grid->eclipse_version;
   }
 
-  // If ACTNUM and ext_actnum are not present - that is is interpreted as all active. 
-  const int * actnum_data;
-  std::vector<int> actnum_product;
-  if (ecl_file_get_num_named_kw(ecl_file , ACTNUM_KW) > grid_nr) {
-    actnum_kw = ecl_file_iget_named_kw( ecl_file , ACTNUM_KW    , grid_nr);
-    actnum_data = ecl_kw_get_int_ptr(actnum_kw);
-    if (ext_actnum) {
-      int size = ecl_kw_get_size(actnum_kw);
-      actnum_product.resize(size);
-      for (int i = 0; i < size; i++)
-        actnum_product[i] = actnum_data[i] * ext_actnum[i];
-      actnum_data = actnum_product.data();
+  /*
+    If ext_actnum is present that is used as ACTNUM, and the file is not checked
+    for an ACTNUM keyword at all.
+  */
+  const int * actnum_data = NULL;
+  if (ext_actnum)
+    actnum_data = ext_actnum;
+  else {
+    if (ecl_file_get_num_named_kw(ecl_file , ACTNUM_KW) > grid_nr) {
+      actnum_kw = ecl_file_iget_named_kw( ecl_file , ACTNUM_KW    , grid_nr);
+      actnum_data = ecl_kw_get_int_ptr(actnum_kw);
     }
   }
-  else
-    actnum_data = ext_actnum;
-
 
   if (grid_nr == 0) {
     /* MAPAXES and COARSENING only apply to the global grid. */

--- a/lib/ecl/tests/ecl_grid_ext_actnum.cpp
+++ b/lib/ecl/tests/ecl_grid_ext_actnum.cpp
@@ -41,12 +41,12 @@ void test_1() {
 
     std::vector<int> ext_actnum = {0, 1, 0, 1, 1, 1};
     ecl_grid_type * grid = ecl_grid_alloc_ext_actnum(filename1, ext_actnum.data());
-    test_assert_int_equal( 2, ecl_grid_get_nactive(grid) );
-    test_assert_int_equal( 1, ecl_grid_get_nactive_fracture(grid) );
+    test_assert_int_equal( 4, ecl_grid_get_nactive(grid) );
+    test_assert_int_equal( 0, ecl_grid_get_nactive_fracture(grid) );
     test_assert_true( !ecl_grid_cell_active1(grid, 0) );
 
     test_assert_true( !ecl_grid_cell_active1(grid, 2) );
-    test_assert_true( !ecl_grid_cell_active1(grid, 3) );
+    test_assert_true(  ecl_grid_cell_active1(grid, 3) );
     test_assert_true(  ecl_grid_cell_active1(grid, 4) );
     test_assert_true(  ecl_grid_cell_active1(grid, 5) );
 


### PR DESCRIPTION
**Issue**
Resolves #605

**Approach**
Just remove the code multiplying external and internal actnum. As mentioned in #605 the original implementation was a best guess - seems it was wrong.

NB: Before this is merged it would be good if @magnesj could verify that the number of elements in the solution vectors like `PRESSURE` and `SWAT`agree with the number of 1 values in the `ext_actnum` field.
