### PR TITLE
Silence warnings on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ endif()
 
 if (MSVC)
     add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4996" )
+    add_definitions( "/wd4244 /wd4267 /wd4013 /wd4190 /wd4018 /wd4477 /wd4098 /wd4293 /wd4305 /wd4020 /wd4028 /wd4715 /wd4804 /wd4090")
 endif()
 
 


### PR DESCRIPTION
Compiling on Windows using Visual Studio 2017 generates  quite many warnings. This pull request will silence some of these warnings. The source code should be adjusted so this suppression list can be made shorter.