### PR TITLE
FWrite EGRID2: Infer Format Flag From Filename

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -329,6 +329,7 @@ foreach (name   ecl_alloc_cpgrid
                 ecl_grid_copy
                 ecl_grid_create
                 ecl_grid_DEPTHZ
+                ecl_grid_fwrite
                 ecl_grid_unit_system
                 ecl_grid_export
                 ecl_grid_init_fwrite

--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -6854,6 +6854,12 @@ static void ecl_grid_fwrite_EGRID__( ecl_grid_type * grid , fortio_type * fortio
 
 void ecl_grid_fwrite_EGRID2( ecl_grid_type * grid , const char * filename, ert_ecl_unit_enum output_unit) {
   bool fmt_file        = false;
+  {
+    bool is_fmt;
+
+    if (ecl_util_get_file_type( filename , &is_fmt, NULL ) != ECL_OTHER_FILE)
+      fmt_file = is_fmt;
+  }
   fortio_type * fortio = fortio_open_writer( filename , fmt_file , ECL_ENDIAN_FLIP );
 
   ecl_grid_fwrite_EGRID__( grid , fortio, output_unit);

--- a/lib/ecl/tests/ecl_grid_fwrite.cpp
+++ b/lib/ecl/tests/ecl_grid_fwrite.cpp
@@ -37,6 +37,62 @@ void test_fwrite_EGRID(ecl_grid_type * grid ) {
   test_work_area_free( work_area );
 }
 
+namespace {
+  void test_fwrite_fmt_vs_unfmt( ) {
+    ecl::util::TestArea ta( "fmt_file" );
+    ecl_grid_type * ecl_grid = ecl_grid_alloc_rectangular( 5 , 5 , 5 , 1 , 1 , 1 , nullptr);
+
+    /* .FEGRID -> formatted */
+    {
+      ecl_grid_fwrite_EGRID2( ecl_grid , "CASE.FEGRID" , ECL_METRIC_UNITS );
+      test_assert_true( util_fmt_bit8( "CASE.FEGRID" ) );
+    }
+
+    /* .EGRID -> unformatted */
+    {
+      ecl_grid_fwrite_EGRID2( ecl_grid , "CASE.EGRID" , ECL_METRIC_UNITS );
+      test_assert_false( util_fmt_bit8( "CASE.EGRID" ) );
+    }
+
+    /* Unknown -> unformatted */
+    {
+      ecl_grid_fwrite_EGRID2( ecl_grid , "CASE.UNKNOWN" , ECL_METRIC_UNITS );
+      test_assert_false( util_fmt_bit8( "CASE.UNKNOWN" ) );
+    }
+
+    /* Abuse: .FUNRST -> formatted */
+    {
+      ecl_grid_fwrite_EGRID2( ecl_grid , "CASE.FUNRST" , ECL_METRIC_UNITS );
+      test_assert_true( util_fmt_bit8( "CASE.FUNRST" ) );
+    }
+
+    /* Abuse: .FSMSPEC -> formatted */
+    {
+      ecl_grid_fwrite_EGRID2( ecl_grid , "CASE.FSMSPEC" , ECL_METRIC_UNITS );
+      test_assert_true( util_fmt_bit8( "CASE.FSMSPEC" ) );
+    }
+
+    /* Abuse: .F0001 -> formatted */
+    {
+      ecl_grid_fwrite_EGRID2( ecl_grid , "CASE.F0001" , ECL_METRIC_UNITS );
+      test_assert_true( util_fmt_bit8( "CASE.F0001" ) );
+    }
+
+    /* Abuse: .X1234 -> unformatted */
+    {
+      ecl_grid_fwrite_EGRID2( ecl_grid , "CASE.X1234" , ECL_METRIC_UNITS );
+      test_assert_false( util_fmt_bit8( "CASE.X1234" ) );
+    }
+
+    /* Abuse: .UNSMRY -> unformatted */
+    {
+      ecl_grid_fwrite_EGRID2( ecl_grid , "CASE.UNSMRY" , ECL_METRIC_UNITS );
+      test_assert_false( util_fmt_bit8( "CASE.UNSMRY" ) );
+    }
+
+    ecl_grid_free( ecl_grid );
+  }
+}
 
 int main( int argc , char **argv) {
   if (argc > 1) {
@@ -47,4 +103,6 @@ int main( int argc , char **argv) {
 
     ecl_grid_free( grid );
   }
+
+  test_fwrite_fmt_vs_unfmt( );
 }

--- a/lib/ecl/tests/ecl_grid_fwrite.cpp
+++ b/lib/ecl/tests/ecl_grid_fwrite.cpp
@@ -39,10 +39,12 @@ void test_fwrite_EGRID(ecl_grid_type * grid ) {
 
 
 int main( int argc , char **argv) {
-  const char * src_file = argv[1];
-  ecl_grid_type * grid = ecl_grid_alloc( src_file );
+  if (argc > 1) {
+    const char * src_file = argv[1];
+    ecl_grid_type * grid = ecl_grid_alloc( src_file );
 
-  test_fwrite_EGRID( grid );
+    test_fwrite_EGRID( grid );
 
-  ecl_grid_free( grid );
+    ecl_grid_free( grid );
+  }
 }


### PR DESCRIPTION
This commit extends the ecl_grid_fwrite_EGRID2 library function to consult the filename in order to infer whether or not to create a formatted EGRID file.  Previously, this function would always create an unformatted EGRID output file, irrespective of filename extension.

**Issue**
Resolves part of OPM/opm-simulators#1784.

**Approach**
_Consult the filename's extension to determine whether or not to create a formatted output file_