### PR TITLE
Update module hierarchy used in import of Python examples

### DIFF
--- a/python/docs/examples/avg_pressure.py
+++ b/python/docs/examples/avg_pressure.py
@@ -3,7 +3,8 @@ import sys
 import matplotlib.pyplot as plt
 
 # Import the required symbols from the ecl.ecl package.
-from ecl.ecl import EclFile, EclGrid, EclRegion, EclRestartFile
+from ecl.eclfile import EclFile, EclRestartFile
+from ecl.grid import EclGrid, EclRegion
 
 
 # Calculate the average pressure for all the cells in the region using

--- a/python/docs/examples/cmp_nnc.py
+++ b/python/docs/examples/cmp_nnc.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 import sys
 from operator import itemgetter
-from ecl.ecl import EclFile, EclGrid
+from ecl.eclfile import EclFile
+from ecl.grid import EclGrid
 
 
 

--- a/python/docs/examples/grid_info.py
+++ b/python/docs/examples/grid_info.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
-from ecl.ecl import EclGrid, EclRegion
+from ecl.grid import EclGrid, EclRegion
 
 
 def volume_min_max(grid):


### PR DESCRIPTION
At least for installed python modules there is no ecl.ecl anymore that contains all imported files. This PR updates the examples to use the correct hierarchy.
