### PR TITLE
Make global index used consistent in cmp_nnc.py

### DIFF
--- a/python/docs/examples/cmp_nnc.py
+++ b/python/docs/examples/cmp_nnc.py
@@ -23,6 +23,10 @@ if __name__ == "__main__":
 
     nnc_list = sorted(nnc_list, key = itemgetter(0))
     for (g1,g2,T) in nnc_list:
+        # grid_ijk assumes 0-based indexing, g1/g2 are 1-based (FORTRAN)
+        # Convert them to zero based ones.
+        g1 = g1 - 1
+        g2 = g2 - 1
         i1,j1,k1 = grid.get_ijk( global_index = g1 )
         i2,j2,k2 = grid.get_ijk( global_index = g2 )
 

--- a/python/docs/examples/cmp_nnc.py
+++ b/python/docs/examples/cmp_nnc.py
@@ -30,7 +30,8 @@ if __name__ == "__main__":
         i1,j1,k1 = grid.get_ijk( global_index = g1 )
         i2,j2,k2 = grid.get_ijk( global_index = g2 )
 
-        print "(%02d,%02d,%02d) -> (%02d,%02d,%02d)  T:%g" % (i1,j1,k1,i2,j2,k2,T)
+        # print 1-based indices just like in eclipse PRT files
+        print "(%02d,%02d,%02d) -> (%02d,%02d,%02d)  T:%g" % (i1+1,j1+1,k1+1,i2+1,j2+1,k2+1,T)
 
 
 


### PR DESCRIPTION
**Issue**
Resolves #613 

**Approach**
We simply decrement the 1-based globale indices read from the eclipse files before passing them to the libel functions.

In addition the second commit resorts to printing the ijk indices as 1-based. That is a matter of taste of course but seems less surprising to me,