### PR TITLE
Improve robustness

### DIFF
--- a/lib/ecl/ecl_smspec.cpp
+++ b/lib/ecl/ecl_smspec.cpp
@@ -699,10 +699,15 @@ static void ecl_smspec_install_special_keys( ecl_smspec_type * ecl_smspec , cons
       ecl_smspec_get_well_var_index( smspec , well_name , var );
   */
 
-  const char * well            = smspec_node_get_wgname( &smspec_node );
-  const char * group           = well;
-  const int num                = smspec_node_get_num(&smspec_node);
-  const char * keyword         = smspec_node_get_keyword(&smspec_node);
+  std::string well;
+  if (smspec_node_get_wgname(&smspec_node)) well = smspec_node_get_wgname(&smspec_node);
+
+  std::string group = well;
+  const int num = smspec_node_get_num(&smspec_node);
+
+  std::string keyword;
+  if (smspec_node_get_keyword(&smspec_node)) keyword = smspec_node_get_keyword(&smspec_node);
+
   ecl_smspec_var_type var_type = smspec_node_get_var_type(&smspec_node );
 
   switch(var_type) {

--- a/lib/ecl/ecl_smspec.cpp
+++ b/lib/ecl/ecl_smspec.cpp
@@ -232,6 +232,8 @@ static const char* smspec_required_keywords[] = {
 namespace {
 
 const ecl::smspec_node * ecl_smspec_get_var_node( const node_map& mp, const char * var) {
+    if (!var) return nullptr;
+
     const auto it = mp.find(var);
     if (it == mp.end())
       return nullptr;

--- a/lib/ecl/smspec_node.cpp
+++ b/lib/ecl/smspec_node.cpp
@@ -329,7 +329,7 @@ std::string smspec_alloc_completion_ijk_key( const char * join_string , const st
                                join_string ,
                                i , j , k );
   else
-    return NULL;
+    return "";
 }
 
 
@@ -343,7 +343,7 @@ std::string smspec_alloc_completion_num_key( const char * join_string , const st
                               join_string ,
                               num );
   else
-    return NULL;
+    return "";
 }
 
 /*
@@ -406,7 +406,7 @@ std::string smspec_alloc_segment_key( const char * join_string , const std::stri
                               join_string ,
                               num );
   else
-    return NULL;
+    return "";
 }
 
 
@@ -419,7 +419,7 @@ std::string smspec_alloc_local_well_key( const char * join_string , const std::s
                                join_string ,
                                wgname.c_str());
   else
-    return NULL;
+    return "";
 }
 
 std::string smspec_alloc_local_completion_key( const char * join_string, const std::string& keyword , const std::string& lgr_name , const std::string& wgname , int i , int j , int k) {
@@ -433,7 +433,7 @@ std::string smspec_alloc_local_completion_key( const char * join_string, const s
                               join_string ,
                               i,j,k);
   else
-    return NULL;
+    return "";
 }
 
 /*****************************************************************/


### PR DESCRIPTION
**Issue**
Multiple test cases has triggered issues related to null pointer access and assignment of NULL to a std::string causing crash.

Resolves parts of #585

**Approach**
Guard null pointer access
Do not assign NULL to a std::string
