### PR TITLE
StringList raise a TypeError if initialized from a string

### DIFF
--- a/python/ecl/util/util/stringlist.py
+++ b/python/ecl/util/util/stringlist.py
@@ -76,11 +76,15 @@ class StringList(BaseCClass):
 
         c_ptr = self._alloc()
         super(StringList, self).__init__(c_ptr)
-        if initial:
-            self._append_all(initial)
+        if not initial:
+            return
 
-    def _append_all(self, lst):
-        for s in lst:
+        if isinstance(initial, string_types):
+            raise TypeError((
+                'Cannot initialize a StringList from "{initial}".\n'
+                'Did you mean "[{initial}]"?'
+                ).format(initial=initial))
+        for s in initial:
             if isinstance(s, bytes):
                 s.decode('ascii')
             if isinstance(s, string_types):

--- a/python/tests/util_tests/test_string_list.py
+++ b/python/tests/util_tests/test_string_list.py
@@ -20,6 +20,22 @@ class StringListTest(TestCase):
 
         self.assertEqual(python_list_of_strings, ["A", "list"])
 
+
+    def test_fail_init(self):
+        with self.assertRaises(TypeError):
+            StringList(initial="a string instead of a list")
+
+        with self.assertRaises(TypeError):
+            StringList(initial=u"a unicode string instead of a list")
+
+        with self.assertRaises(TypeError):
+            StringList(initial=b"a bytearray instead of a list")
+
+        with self.assertRaises(TypeError):
+            StringList(initial=[2, 4, 5])
+
+
+
     def test_iterate(self):
         s = ["A", "list", "of", "strings"]
         s1 = StringList(initial=s)


### PR DESCRIPTION
**Issue**
Previously, calling `StringList("alpha")` would result in a `StringList`
object with elements `a`, `l`, `p`, `h`, `a` which is arguably a misuse
of this class

**Approach**
Explicitly check the type of the parameter passed to the constructor
