### PR TITLE
Active cells from PORV : Assign combined bit mask

### DIFF
--- a/lib/ecl/ecl_kw_functions.cpp
+++ b/lib/ecl/ecl_kw_functions.cpp
@@ -136,7 +136,7 @@ ecl_kw_type * ecl_kw_alloc_actnum(const ecl_kw_type * porv_kw, float porv_limit)
     return NULL;
 
   if (!util_string_equal(PORV_KW, ecl_kw_get_header(porv_kw)))
-    return NULL;
+        return NULL;
 
   const int size = ecl_kw_get_size(porv_kw);
   ecl_kw_type * actnum_kw = ecl_kw_alloc(ACTNUM_KW, size, ECL_INT);
@@ -150,5 +150,30 @@ ecl_kw_type * ecl_kw_alloc_actnum(const ecl_kw_type * porv_kw, float porv_limit)
       actnum_values[i] = 0;
   }
 
-  return actnum_kw;
+/*
+    Allocate actnum, and assign actnum_bitmask to all cells with pore volume
+    larger than zero. The bit mask can be any combination of
+    CELL_ACTIVE_MATRIX and CELL_ACTIVE_FRACTURE.
+    See documentation in top of ecl_grid.cpp
+*/
+ecl_kw_type * ecl_kw_alloc_actnum_bitmask(const ecl_kw_type * porv_kw, float porv_limit, int actnum_bitmask) {
+    if (!ecl_type_is_float(porv_kw->data_type))
+        return NULL;
+
+    if (!util_string_equal(PORV_KW, ecl_kw_get_header(porv_kw)))
+        return NULL;
+
+    const int size = ecl_kw_get_size(porv_kw);
+    ecl_kw_type * actnum_kw = ecl_kw_alloc(ACTNUM_KW, size, ECL_INT);
+    const float * porv_values = ecl_kw_get_float_ptr(porv_kw);
+    int * actnum_values = ecl_kw_get_int_ptr(actnum_kw);
+
+    for (int i = 0; i < size; i++) {
+        if (porv_values[i] > porv_limit)
+            actnum_values[i] = actnum_bitmask;
+        else
+            actnum_values[i] = 0;
+    }
+
+    return actnum_kw;
 }

--- a/lib/ecl/ecl_kw_functions.cpp
+++ b/lib/ecl/ecl_kw_functions.cpp
@@ -143,16 +143,9 @@ ecl_kw_type * ecl_kw_alloc_actnum(const ecl_kw_type * porv_kw, float porv_limit)
   const float * porv_values = ecl_kw_get_float_ptr(porv_kw);
   int * actnum_values = ecl_kw_get_int_ptr( actnum_kw);
 
-  // When PORV is used as criteria, make sure all active cells are assigned both
-  // active matrix state and active fracture state. This will make sure that
-  // both single porosity models and dual porosity models are initialized with
-  // the correct bit mask. See documentation in top of ecl_grid.cpp
-  //
-  const int combinedActnumValueForMatrixAndFracture = CELL_ACTIVE_MATRIX + CELL_ACTIVE_FRACTURE;
-
   for (int i=0; i < size; i++) {
     if (porv_values[i] > porv_limit)
-      actnum_values[i] = combinedActnumValueForMatrixAndFracture;
+      actnum_values[i] = 1;
     else
       actnum_values[i] = 0;
   }

--- a/lib/ecl/ecl_kw_functions.cpp
+++ b/lib/ecl/ecl_kw_functions.cpp
@@ -143,9 +143,16 @@ ecl_kw_type * ecl_kw_alloc_actnum(const ecl_kw_type * porv_kw, float porv_limit)
   const float * porv_values = ecl_kw_get_float_ptr(porv_kw);
   int * actnum_values = ecl_kw_get_int_ptr( actnum_kw);
 
+  // When PORV is used as criteria, make sure all active cells are assigned both
+  // active matrix state and active fracture state. This will make sure that
+  // both single porosity models and dual porosity models are initialized with
+  // the correct bit mask. See documentation in top of ecl_grid.cpp
+  //
+  const int combinedActnumValueForMatrixAndFracture = CELL_ACTIVE_MATRIX + CELL_ACTIVE_FRACTURE;
+
   for (int i=0; i < size; i++) {
     if (porv_values[i] > porv_limit)
-      actnum_values[i] = 1;
+      actnum_values[i] = combinedActnumValueForMatrixAndFracture;
     else
       actnum_values[i] = 0;
   }

--- a/lib/ecl/ecl_kw_functions.cpp
+++ b/lib/ecl/ecl_kw_functions.cpp
@@ -150,6 +150,10 @@ ecl_kw_type * ecl_kw_alloc_actnum(const ecl_kw_type * porv_kw, float porv_limit)
       actnum_values[i] = 0;
   }
 
+  return actnum_kw;
+}
+
+
 /*
     Allocate actnum, and assign actnum_bitmask to all cells with pore volume
     larger than zero. The bit mask can be any combination of
@@ -157,23 +161,23 @@ ecl_kw_type * ecl_kw_alloc_actnum(const ecl_kw_type * porv_kw, float porv_limit)
     See documentation in top of ecl_grid.cpp
 */
 ecl_kw_type * ecl_kw_alloc_actnum_bitmask(const ecl_kw_type * porv_kw, float porv_limit, int actnum_bitmask) {
-    if (!ecl_type_is_float(porv_kw->data_type))
-        return NULL;
+  if (!ecl_type_is_float(porv_kw->data_type))
+    return NULL;
 
-    if (!util_string_equal(PORV_KW, ecl_kw_get_header(porv_kw)))
-        return NULL;
+  if (!util_string_equal(PORV_KW, ecl_kw_get_header(porv_kw)))
+    return NULL;
 
-    const int size = ecl_kw_get_size(porv_kw);
-    ecl_kw_type * actnum_kw = ecl_kw_alloc(ACTNUM_KW, size, ECL_INT);
-    const float * porv_values = ecl_kw_get_float_ptr(porv_kw);
-    int * actnum_values = ecl_kw_get_int_ptr(actnum_kw);
+  const int size = ecl_kw_get_size(porv_kw);
+  ecl_kw_type * actnum_kw = ecl_kw_alloc(ACTNUM_KW, size, ECL_INT);
+  const float * porv_values = ecl_kw_get_float_ptr(porv_kw);
+  int * actnum_values = ecl_kw_get_int_ptr(actnum_kw);
 
-    for (int i = 0; i < size; i++) {
-        if (porv_values[i] > porv_limit)
-            actnum_values[i] = actnum_bitmask;
-        else
-            actnum_values[i] = 0;
-    }
+  for (int i = 0; i < size; i++) {
+    if (porv_values[i] > porv_limit)
+      actnum_values[i] = actnum_bitmask;
+    else
+      actnum_values[i] = 0;
+  }
 
-    return actnum_kw;
+  return actnum_kw;
 }

--- a/lib/include/ert/ecl/ecl_kw.hpp
+++ b/lib/include/ert/ecl/ecl_kw.hpp
@@ -88,6 +88,7 @@ extern "C" {
   void           ecl_kw_fread(ecl_kw_type * , fortio_type * );
   ecl_kw_type *  ecl_kw_fread_alloc(fortio_type *);
   ecl_kw_type *  ecl_kw_alloc_actnum(const ecl_kw_type * porv_kw, float porv_limit);
+  ecl_kw_type *  ecl_kw_alloc_actnum_bitmask(const ecl_kw_type * porv_kw, float porv_limit, int actnum_bitmask);
   void           ecl_kw_free_data(ecl_kw_type *);
   void           ecl_kw_fread_indexed_data(fortio_type * fortio, offset_type data_offset, ecl_data_type, int element_count, const int_vector_type* index_map, char* buffer);
   void           ecl_kw_free(ecl_kw_type *);


### PR DESCRIPTION
When PORV is used as criteria, make sure all active cells are assigned both active matrix state and active fracture state. This will make sure that both single porosity models and dual porosity models are initialized with the correct bit mask.

**Issue**
Resolves #626
