### PR TITLE
Add env variable to skip signal handler setup

### DIFF
--- a/python/ecl/__init__.py
+++ b/python/ecl/__init__.py
@@ -53,6 +53,7 @@ If the fixed path, given by the default ../../lib64 or ERT_LIBRARY_PATH
 alternative fails, the loader will try the default load behaviour
 before giving up completely.
 """
+import os
 import os.path
 import sys
 
@@ -134,7 +135,8 @@ from .ecl_util import EclFileEnum, EclFileFlagEnum, EclPhaseEnum, EclUnitTypeEnu
 from .util.util import EclVersion
 from .util.util import updateAbortSignals
 
-updateAbortSignals( )
+if not os.getenv('ECL_SKIP_SIGNAL'):
+    updateAbortSignals( )
 
 def root():
     """


### PR DESCRIPTION
**Issue**
The users of a library should be in charge of what to do when signals are sent

**Approach**
Add an environment library `ECL_SKIP_SIGNAL` that users can set before loading `ecl`.

If `ECL_SKIP_SIGNAL` is set, we skip the `updateAbortSignals()` call in the ecl module init.
