### PR TITLE
Fix typo in ecl_grav_calc.hpp

### DIFF
--- a/lib/include/ert/ecl/ecl_grav_calc.hpp
+++ b/lib/include/ert/ecl/ecl_grav_calc.hpp
@@ -22,9 +22,9 @@
 extern "C" {
 #endif
 
-#include <etr/ecl/ecl_kw.h>
-#include <etr/ecl/ecl_grid.h>
-#include <etr/ecl/ecl_file.h>
+#include <ert/ecl/ecl_kw.h>
+#include <ert/ecl/ecl_grid.h>
+#include <ert/ecl/ecl_file.h>
 
 double ecl_grav_phase_deltag( double utm_x ,
                               double utm_y ,


### PR DESCRIPTION
**Approach**
Fix typo in ecl_grav_calc.hpp: include <etr/... instead of <ert/...
