### PR TITLE
Restore previous abort handler if it was present

### DIFF
--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -25,6 +25,7 @@
 #include <stdarg.h>
 #include <sys/types.h>
 #include <time.h>
+#include <signal.h>
 
 
 #include <ert/util/ert_api_config.hpp>
@@ -386,6 +387,13 @@ typedef bool (walk_dir_callback_ftype)   (const char * , /* The current director
   CONTAINS_HEADER(time_t);
   CONTAINS_HEADER(size_t);
 #undef CONTAINS_HEADER
+
+/* Redefining sighandler_t in case it isn't defined (Windows).
+This is harmless on other platforms. */
+typedef void (*sighandler_t)(int);
+/* When installing our abort handler, remeber if there was a previous one,
+* so we can call that afterwards */
+extern sighandler_t previous_abort_handler;
 
 #ifdef _MSC_VER
 #define util_abort(fmt , ...) util_abort__(__FILE__ , __func__ , __LINE__ , fmt , __VA_ARGS__)

--- a/lib/util/util_abort_simple.c
+++ b/lib/util/util_abort_simple.c
@@ -29,7 +29,6 @@ void util_abort__(const char * file , const char * function , int line , const c
   }
   fprintf(stderr,"-----------------------------------------------------------------\n");
 
-  signal(SIGABRT , SIG_DFL);
   fprintf(stderr , "Aborting ... \n");
   assert(0);
   abort();

--- a/python/ecl/__init__.py
+++ b/python/ecl/__init__.py
@@ -53,7 +53,6 @@ If the fixed path, given by the default ../../lib64 or ERT_LIBRARY_PATH
 alternative fails, the loader will try the default load behaviour
 before giving up completely.
 """
-import os
 import os.path
 import sys
 
@@ -135,8 +134,8 @@ from .ecl_util import EclFileEnum, EclFileFlagEnum, EclPhaseEnum, EclUnitTypeEnu
 from .util.util import EclVersion
 from .util.util import updateAbortSignals
 
-if not os.getenv('ECL_SKIP_SIGNAL'):
-    updateAbortSignals( )
+
+updateAbortSignals( )
 
 def root():
     """

--- a/python/ecl/util/util/install_abort_signals.py
+++ b/python/ecl/util/util/install_abort_signals.py
@@ -1,15 +1,17 @@
 from ecl import EclPrototype
-
+import os
 
 def installAbortSignals():
-    install_signals()
+    if not os.getenv('ECL_SKIP_SIGNAL'):
+        install_signals()
 
 
 def updateAbortSignals():
     """
     Will install the util_abort_signal for all UNMODIFIED signals.
     """
-    update_signals()
+    if not os.getenv('ECL_SKIP_SIGNAL'):
+        update_signals()
 
 
 install_signals = EclPrototype("void util_install_signals()")


### PR DESCRIPTION
In order to have both c and python stack traces on errors, we
call pythons abort handler after done with util_abort. Also
move the check for flag ECL_SKIP_SIGNAL, since the method
to install signal handler was called several places.

Also fixes an error in util_abort where it would deadlock if it could not open a file, and then called util_abort again.