### PR TITLE
Remove pytest collection warning for non-test class which is collected

### DIFF
--- a/python/ecl/util/test/test_area.py
+++ b/python/ecl/util/test/test_area.py
@@ -20,6 +20,9 @@ from ecl import EclPrototype
 
 
 class TestArea(BaseCClass):
+
+    __test__ = False
+
     _test_area_alloc           = EclPrototype("void* test_work_area_alloc__( char*, bool )" , bind = False)
     _free                      = EclPrototype("void test_work_area_free( test_area )")
     _install_file              = EclPrototype("void test_work_area_install_file( test_area , char* )")
@@ -113,6 +116,9 @@ class TestArea(BaseCClass):
 
 
 class TestAreaContext(object):
+
+    __test__ = False
+
     def __init__(self, test_name, store_area=False):
         self.test_name = test_name
         self.store_area = store_area


### PR DESCRIPTION
When running python test discovery, several classes have test_* or *_test
names, which causes them to be discovered, however they are not tests,
which gives a warning.