### PR TITLE
Change string output to space pad when writing binary ecl_kw

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -341,6 +341,7 @@ foreach (name   ecl_alloc_cpgrid
                 ecl_grid_cell_contains
                 ecl_unsmry_loader_test
                 ecl_init_file
+                ecl_kw_space_pad
                 ecl_kw_cmp_string
                 ecl_kw_equal
                 ecl_kw_fread

--- a/lib/ecl/ecl_kw.cpp
+++ b/lib/ecl/ecl_kw.cpp
@@ -283,7 +283,14 @@ static char * ecl_kw_alloc_output_buffer(const ecl_kw_type * ecl_kw) {
     for (int i=0; i < ecl_kw->size; i++) {
       size_t buffer_offset = i * sizeof_iotype;
       size_t data_offset = i * sizeof_ctype;
-      memcpy(&buffer[buffer_offset], &ecl_kw->data[data_offset], sizeof_iotype);
+      size_t string_length = strlen(&ecl_kw->data[data_offset]);
+
+      for (size_t i=0; i < string_length; i++)
+        buffer[buffer_offset + i] = ecl_kw->data[data_offset + i];
+
+      // Pad with spaces
+      for (size_t i = string_length; i < sizeof_iotype; i++)
+        buffer[buffer_offset + i] = ' ';
     }
 
     return buffer;
@@ -332,7 +339,9 @@ static void ecl_kw_load_from_input_buffer(ecl_kw_type * ecl_kw, char * buffer) {
   }
 
   /*
-    Special case: insert '\0' termination at end of strings loaded from file.
+    Special case: insert '\0' termination at end of strings loaded from file;
+    when writing out again strlen() will be called on data - i.e. it is
+    paramount to add this '\0'.
   */
   if (ecl_type_is_char(ecl_kw->data_type) || ecl_type_is_string(ecl_kw->data_type)) {
     const char null_char = '\0';

--- a/lib/ecl/tests/ecl_kw_space_pad.cpp
+++ b/lib/ecl/tests/ecl_kw_space_pad.cpp
@@ -1,0 +1,52 @@
+/*
+  Copyright (C) 2019  Equinor ASA, Norway.
+
+  The file 'ecl_grid_unit_system.c' is part of ERT - Ensemble based Reservoir Tool.
+
+  ERT is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.
+
+  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+  for more details.
+*/
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <ert/util/test_util.hpp>
+#include <ert/util/test_work_area.hpp>
+
+#include <ert/ecl/ecl_kw.hpp>
+
+
+
+int main(int argc, char **argv) {
+  ecl::util::TestArea ta("grid_unit_system");
+
+  // 1. Write a ecl_kw instance with string data - uninitialized.
+  {
+    ecl_kw_type * ecl_kw = ecl_kw_alloc("SPACE", 1, ECL_CHAR);
+    fortio_type * f = fortio_open_writer("file", false, true);
+    ecl_kw_fwrite(ecl_kw, f);
+    fortio_fclose(f);
+    ecl_kw_free( ecl_kw );
+  }
+
+  // 2. Open file with normal fopen() and verify that the data section consists of only spaces.
+  {
+    FILE * stream = util_fopen("file", "r");
+    char buffer[8];
+    size_t offset = 4 + 16 + 4 + 4;
+    fseek(stream, offset, SEEK_SET);
+    fread(buffer, 1, 8, stream);
+    for (int i=0; i < 8; i++)
+      test_assert_int_equal(buffer[i], ' ');
+
+    fclose(stream);
+  }
+}


### PR DESCRIPTION
The character/string data in ecl_kw are in blocks of 8 characters, the internalized datatype is a 9 character buffer with \0 termination. When writing to disk the first eight characters are copied verbatim, this implies that for strings shorter than 8 characters random trailing garbage will be written to disk.

With this PR the output is explicitly space padded.