### PR TITLE
Check for sighandler_t and redifine only if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ try_compile( HAVE_SIGBUS  ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/Tests/
 try_compile( HAVE_PID_T   ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/Tests/test_pid_t.c )
 try_compile( HAVE_MODE_T  ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/Tests/test_mode_t.c )
 try_compile( ERT_HAVE_ISFINITE ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/Tests/test_isfinite.c)
+try_compile( HAVE_SIGHANDLER_T ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/Tests/test_have_sighandler.c)
 
 if (ERT_HAVE_READLINKAT)
   try_compile( ERT_HAVE_READLINKAT_DECLARATION

--- a/cmake/Tests/test_have_sighandler.c
+++ b/cmake/Tests/test_have_sighandler.c
@@ -1,0 +1,6 @@
+#include <signal.h>
+
+
+void main(int argc, char *argv[]) {
+  sighandler_t my_handler = SIG_IGN;
+}

--- a/lib/build_config.h.in
+++ b/lib/build_config.h.in
@@ -26,7 +26,7 @@
 #cmakedefine HAVE_CXX_SHARED_PTR
 #cmakedefine HAVE_POSIX_UNLINK
 #cmakedefine HAVE_WINDOWS_UNLINK
-
+#cmakedefine HAVE_SIGHANDLER_T
 
 #cmakedefine HAVE_POSIX_ACCESS
 #cmakedefine HAVE_WINDOWS__ACCESS

--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -25,7 +25,6 @@
 #include <stdarg.h>
 #include <sys/types.h>
 #include <time.h>
-#include <signal.h>
 
 
 #include <ert/util/ert_api_config.hpp>
@@ -387,13 +386,6 @@ typedef bool (walk_dir_callback_ftype)   (const char * , /* The current director
   CONTAINS_HEADER(time_t);
   CONTAINS_HEADER(size_t);
 #undef CONTAINS_HEADER
-
-/* Redefining sighandler_t in case it isn't defined (Windows).
-This is harmless on other platforms. */
-typedef void (*sighandler_t)(int);
-/* When installing our abort handler, remeber if there was a previous one,
-* so we can call that afterwards */
-extern sighandler_t previous_abort_handler;
 
 #ifdef _MSC_VER
 #define util_abort(fmt , ...) util_abort__(__FILE__ , __func__ , __LINE__ , fmt , __VA_ARGS__)

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -4405,7 +4405,17 @@ char * util_realloc_sprintf(char * s , const char * fmt , ...) {
   The various signals can be found in: /usr/include/bits/signum.h
 */
 
-sighandler_t previous_abort_handler = SIG_IGN;
+/* Redefining sighandler_t in case it isn't defined (Windows).*/
+
+#ifndef HAVE_SIGHANDLER_T
+typedef void (*sighandler_t)(int);
+#endif
+
+/* When installing our abort handler, remeber if there was a previous one,
+ * so we can call that afterwards */
+
+
+static sighandler_t previous_abort_handler = SIG_IGN;
 
 void util_abort_signal(int the_signal) {
     if (previous_abort_handler == SIG_IGN) {


### PR DESCRIPTION
The PR: #634 seems to have broken the build of opm: https://github.com/OPM/opm-common/pull/884

This PR restores that build. The changes in the PR are:

1. There is `try_compile()` based cmake check to look for the `sighandler_t` type, and it is only redeclared if needed.

2. The management of previous signal handler is implemented in the source file instead of the header file.

