### PR TITLE
Set MACOSX_RPATH on by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,12 @@ project( ERT C CXX )
 include(GNUInstallDirs)
 include(TestBigEndian)
 
-if(POLICY CMP0042)
-  cmake_policy(SET CMP0042 OLD)
+if(NOT DEFINED CMAKE_MACOSX_RPATH)
+  # There is some weirdness around this variable, the default value is different depending on
+  # the cmake version, see policy CMP0042.
+  # A more explicit way to treat this would be `cmake_policy(SET CMP0042 NEW)` but that would
+  # fail on CMake 2.8.12 (the variable exists but the policy doesn't)
+  set(CMAKE_MACOSX_RPATH ON)
 endif()
 
 #-----------------------------------------------------------------


### PR DESCRIPTION
Policy CMP0042 was introduced in CMake 3.0 and concerns the default
behavior of the target property MACOSX_RPATH, ie OFF before 3.0 and ON
after 3.0

It is possible that, at a certain point in time, libecl (ert) required
to stick with the old behavior. It is also possible that the code and
the cmake files were changed over time, without proper testing on
MacOSX. It appears that sticking with the old behavior has become
unnecessary, so we are explicitly setting the new default value for
older versions of CMake as well.

This, in turn, allows us to install multiple versions of libecl on the
same machine (eg, in different virtual environments) without resorting
to DYLD_LIBRARY_PATH (which is kind of broken from OSX El Capitan on)
