### PR TITLE
Use six elements from summary STARTDAT keyword

### DIFF
--- a/lib/ecl/ecl_util.cpp
+++ b/lib/ecl/ecl_util.cpp
@@ -1465,8 +1465,8 @@ void ecl_util_init_month_range( time_t_vector_type * date_list , time_t start_da
 
 
 
-time_t ecl_util_make_date__(int mday , int month , int year, int * __year_offset) {
-time_t date;
+static time_t ecl_util_make_datetime__(int sec, int min, int hour, int mday , int month , int year, int * __year_offset) {
+  time_t date;
 
 #ifdef ERT_TIME_T_64BIT_ACCEPT_PRE1970
   *__year_offset = 0;
@@ -1483,10 +1483,14 @@ time_t date;
     offset_initialized = true;
   }
   *__year_offset = year_offset;
-  date = util_make_date_utc(mday , month , year + year_offset);
+  date = util_make_datetime_utc(sec, min, hour, mday , month , year + year_offset);
 #endif
 
   return date;
+}
+
+time_t ecl_util_make_date__(int mday , int month , int year, int * __year_offset) {
+  return ecl_util_make_datetime__(0,0,0,mday, month, year, __year_offset);
 }
 
 
@@ -1496,10 +1500,21 @@ time_t ecl_util_make_date(int mday , int month , int year) {
 }
 
 
+time_t ecl_util_make_datetime(int sec, int min, int hour, int mday , int month , int year) {
+    int year_offset;
+    return ecl_util_make_datetime__( sec, min, hour, mday , month , year , &year_offset);
+}
+
 
 void ecl_util_set_date_values(time_t t , int * mday , int * month , int * year) {
   return util_set_date_values_utc(t,mday,month,year);
 }
+
+void ecl_util_set_datetime_values(time_t t , int * sec, int * min, int * hour, int * mday , int * month , int * year) {
+  return util_set_date_values_utc(t,mday,month,year);
+}
+
+
 
 
 #ifdef ERT_HAVE_UNISTD

--- a/lib/include/ert/ecl/ecl_kw_magic.hpp
+++ b/lib/include/ert/ecl/ecl_kw_magic.hpp
@@ -443,10 +443,13 @@ values (2e20) are denoted with '*'.
 
 
 /* Magic indices used to locate day,month,year from the STARTDAT keyword. */
-#define STARTDAT_DAY_INDEX   0
-#define STARTDAT_MONTH_INDEX 1
-#define STARTDAT_YEAR_INDEX  2
-#define STARTDAT_SIZE        3
+#define STARTDAT_DAY_INDEX          0
+#define STARTDAT_MONTH_INDEX        1
+#define STARTDAT_YEAR_INDEX         2
+#define STARTDAT_HOUR_INDEX         3
+#define STARTDAT_MINUTE_INDEX       4
+#define STARTDAT_MICRO_SECOND_INDEX 5
+#define STARTDAT_SIZE               6
 
 
 /* Magic indices uset to locate the grid dimensions from the DIMENS

--- a/lib/include/ert/ecl/ecl_util.hpp
+++ b/lib/include/ert/ecl/ecl_util.hpp
@@ -134,6 +134,7 @@ int             ecl_util_get_month_nr(const char * month_name);
 int             ecl_util_fname_report_cmp(const void *f1, const void *f2);
 time_t          ecl_util_make_date(int mday , int month , int year);
 time_t          ecl_util_make_date__(int mday , int month , int year, int * year_offset);
+time_t          ecl_util_make_datetime(int sec, int min, int hour, int mday , int month , int year);
 ert_ecl_unit_enum   ecl_util_get_unit_set(const char * data_file);
 
 bool            ecl_util_valid_basename_fmt( const char * basename_fmt );
@@ -144,6 +145,7 @@ int             ecl_util_select_filelist( const char * path , const char * base 
 void            ecl_util_append_month_range( time_t_vector_type * date_list , time_t start_date , time_t end_date , bool force_append_end);
 void            ecl_util_init_month_range( time_t_vector_type * date_list , time_t start_date , time_t end_date);
 void            ecl_util_set_date_values(time_t t , int * mday , int * month , int * year);
+void            ecl_util_set_datetime_values(time_t t , int * sec, int * min, int * hour, int * mday , int * month , int * year);
 bool            ecl_util_path_access(const char * ecl_case);
 #ifdef __cplusplus
 }


### PR DESCRIPTION
In a summary SMSPEC file the start time of the simulation is encoded in the `STARTDAT` keyword. In current version of libecl this is encoded as a three element integer with DAY, MONTH, YEAR, but it turns out that it can optionally also be stored as a six element vector with addition elements HOUR, MINUTE, MICRO_SECOND.

This PR adds the three new elements HOUR, MINUTE, MICRO_SECOND - and optionally reads them if they are present in the file when reading.