### PR TITLE
Call correct time function

### DIFF
--- a/lib/ecl/ecl_util.cpp
+++ b/lib/ecl/ecl_util.cpp
@@ -1511,7 +1511,7 @@ void ecl_util_set_date_values(time_t t , int * mday , int * month , int * year) 
 }
 
 void ecl_util_set_datetime_values(time_t t , int * sec, int * min, int * hour, int * mday , int * month , int * year) {
-  return util_set_date_values_utc(t,mday,month,year);
+  return util_set_datetime_values_utc(t,sec,min,hour,mday,month,year);
 }
 
 

--- a/lib/ecl/tests/ecl_sum_writer.cpp
+++ b/lib/ecl/tests/ecl_sum_writer.cpp
@@ -106,6 +106,7 @@ void test_write_read( ) {
     write_summary( name , start_time , nx , ny , nz , num_dates , num_ministep , ministep_length);
     ecl_sum = ecl_sum_fread_alloc_case( name , ":" );
     test_assert_true( ecl_sum_is_instance( ecl_sum ));
+    test_assert_true( ecl_sum_get_start_time(ecl_sum) == start_time );
 
     /* Time direction */
     test_assert_time_t_equal( start_time , ecl_sum_get_start_time(ecl_sum));


### PR DESCRIPTION
Followup fix to: #642

A central element in #642 is to break down a `time_t` value to a full datetime (year, month, day, hour, minute, second) - where it was previously only broken down to (year,month,day). Unfortunately there was a bug in #642 which lead to the (hour, minute, second) part to be undefined.  

