### PR TITLE
First fix of <type> ** pointer

### DIFF
--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -232,7 +232,7 @@ typedef bool (walk_dir_callback_ftype)   (const char * , /* The current director
   char       * util_alloc_string_copy(const char *);
   char      ** util_stringlist_append_copy(char **  , int , const char * );
   char      ** util_stringlist_append_ref(char **  , int , const char * );
-  char      ** util_alloc_stringlist_copy(const char **, int );
+  char      ** util_alloc_stringlist_copy(char const * const *, int );
   void         util_split_string(const char *, const char *, int *, char ***);
   void         util_path_split(const char * , int *, char ***);
   char       * util_alloc_parent_path( const char * path);

--- a/lib/util/util.c
+++ b/lib/util/util.c
@@ -3100,7 +3100,7 @@ char * util_alloc_strip_copy(const char *src) {
 
 
 
-char ** util_alloc_stringlist_copy(const char **src, int len) {
+char ** util_alloc_stringlist_copy(char const * const * src, int len) {
   if (src != NULL) {
     int i;
     char ** copy = (char**)util_calloc(len , sizeof * copy );


### PR DESCRIPTION
const <type> ** is not very safe as the const is only making sure that the char is constant and not the pointers leading to it. We should consider going to const * const * to ensure we get the behavior intended


