### PR TITLE
Allow mixed case filenames

### DIFF
--- a/lib/ecl/tests/ecl_file.cpp
+++ b/lib/ecl/tests/ecl_file.cpp
@@ -85,10 +85,40 @@ void test_truncated() {
   }
 }
 
+void test_mixed_case() {
+  ecl::util::TestArea ta("mixed_case_file");
+  int num_kw;
+  {
+    ecl_grid_type * grid = ecl_grid_alloc_rectangular(20,20,20,1,1,1,NULL);
+    ecl_grid_fwrite_EGRID2( grid , "TESTcase.EGRID", ECL_METRIC_UNITS );
+    ecl_grid_free( grid );
+  }
+  {
+    ecl_file_type * ecl_file = ecl_file_open("TESTcase.EGRID" , 0 );
+    test_assert_true( ecl_file_is_instance( ecl_file ) );
+    num_kw = ecl_file_get_size( ecl_file );
+    test_assert_int_equal( ecl_file_get_num_distinct_kw( ecl_file ), 11);
+    ecl_file_close( ecl_file );
+  }
+
+  {
+    offset_type file_size = util_file_size( "TESTcase.EGRID");
+    FILE * stream = util_fopen("TESTcase.EGRID" , "r+");
+    util_ftruncate( stream , file_size / 2 );
+    fclose( stream );
+  }
+  {
+    ecl_file_type * ecl_file = ecl_file_open("TESTcase.EGRID" , 0 );
+    test_assert_true( ecl_file_get_size( ecl_file) < num_kw );
+    ecl_file_close( ecl_file );
+  }
+}
+
 
 int main( int argc , char ** argv) {
   test_writable(10);
   test_writable(1337);
   test_truncated();
+  test_mixed_case();
   exit(0);
 }

--- a/lib/ecl/tests/ecl_util_filenames.cpp
+++ b/lib/ecl/tests/ecl_util_filenames.cpp
@@ -36,13 +36,20 @@ void test_filename_case() {
   char * f1 = ecl_util_alloc_filename(NULL, "mixedBase", ECL_EGRID_FILE, false, -1);
   char * f2 = ecl_util_alloc_filename(NULL, "UPPER", ECL_EGRID_FILE, false, -1);
   char * f3 = ecl_util_alloc_filename(NULL , "lower", ECL_EGRID_FILE, false, -1);
+  char * f4 = ecl_util_alloc_filename(NULL , "lower1", ECL_EGRID_FILE, false, -1);
+  char * f5 = ecl_util_alloc_filename(NULL , "UPPER1", ECL_EGRID_FILE, false, -1);
 
-  test_assert_NULL( f1 );
+  test_assert_string_equal( f1 , "mixedBase.EGRID");
   test_assert_string_equal( f2 , "UPPER.EGRID");
   test_assert_string_equal( f3 , "lower.egrid");
+  test_assert_string_equal( f4 , "lower1.egrid");
+  test_assert_string_equal( f5 , "UPPER1.EGRID");
 
+  free(f1);
   free(f2);
   free(f3);
+  free(f4);
+  free(f5);
 }
 
 
@@ -64,6 +71,12 @@ void test_file_list() {
     free( fname);
   }
 
+  for (int i = 0; i < 10; i += 2) {
+    char * fname = util_alloc_sprintf("CaseMiXed.F%04d", i);
+    FILE * stream = util_fopen(fname, "w");
+    fclose(stream);
+    free( fname);
+  }
 
   ecl_util_select_filelist(NULL , "case" , ECL_RESTART_FILE, true, s);
   test_assert_int_equal( stringlist_get_size(s), 5);
@@ -73,8 +86,8 @@ void test_file_list() {
     free( fname);
   }
 
-  ecl_util_select_filelist(NULL , "Case" , ECL_RESTART_FILE, true, s);
-  test_assert_int_equal( stringlist_get_size(s), 0);
+  ecl_util_select_filelist(NULL , "CaseMiXed" , ECL_RESTART_FILE, true, s);
+  test_assert_int_equal( stringlist_get_size(s), 5);
 
 
   util_make_path("path");

--- a/lib/ecl/tests/ecl_valid_basename.cpp
+++ b/lib/ecl/tests/ecl_valid_basename.cpp
@@ -29,22 +29,16 @@
 
 
 int main(int argc , char ** argv) {
-    test_assert_true( ecl_util_valid_basename("ECLIPSE.DATA"));
-    test_assert_true( ecl_util_valid_basename("ECLIPS100.DATA"));
-    test_assert_true( ecl_util_valid_basename("eclipse100.data"));
-    test_assert_true( ecl_util_valid_basename("MYPATH/ECLIPSE.DATA"));
-    test_assert_true( ecl_util_valid_basename("mypath/ECLIPSE.DATA"));
-    test_assert_false( ecl_util_valid_basename("ECLiPS100.DATa"));
-    test_assert_false( ecl_util_valid_basename("mypath/eclipse.DATA"));
-
+    test_assert_true( ecl_util_valid_basename_fmt("ecl_%d.data"));
     test_assert_true( ecl_util_valid_basename_fmt("ECL_%d.DATA"));
     test_assert_true( ecl_util_valid_basename_fmt("ECL_%04d.DATA"));
     test_assert_true( ecl_util_valid_basename_fmt("mypath/ECL_%04d.DATA"));
     test_assert_true( ecl_util_valid_basename_fmt("MYPATH/ECL_%04d.DATA"));
     test_assert_true( ecl_util_valid_basename_fmt("MYPATH/ECL_%04d.DATA"));
-    test_assert_false( ecl_util_valid_basename_fmt("ECL_%d.dATA"));
+    test_assert_true( ecl_util_valid_basename_fmt("ECL_%d.dATA"));
     test_assert_false( ecl_util_valid_basename_fmt("ECL_%s.DATA"));
-    test_assert_false( ecl_util_valid_basename_fmt("mypath/ECL_%d.dATA"));
+    test_assert_false( ecl_util_valid_basename_fmt("ECL_%f.DATA"));
+    test_assert_true( ecl_util_valid_basename_fmt("mypath/ECL_%d.dATA"));
 
     exit(0);
 }


### PR DESCRIPTION
**Issue**
Resolves #582 

**Approach**
Remove mixed case checking in filename. Preserve checking of upper case such that the file extensions added by `ecl_util_alloc_filename` will be consistent with previous behavior:
```
ecl_util_alloc_filename(NULL, "UPPER", ECL_EGRID_FILE, false, -1) -->  UPPER.EGRID
ecl_util_alloc_filename(NULL , "lower", ECL_EGRID_FILE, false, -1) --> lower.egrid
```
Mixed case will get uppercase extension
```
ecl_util_alloc_filename(NULL, "miXed", ECL_EGRID_FILE, false, -1) -->  miXed.EGRID
```