### PR TITLE
Fix use of decorators to include documentation

### DIFF
--- a/python/ecl/grid/ecl_region.py
+++ b/python/ecl/grid/ecl_region.py
@@ -25,6 +25,7 @@ combined e.g. with logical &.
 When the selection process is complete the region instance can be
 queried for the corresponding list of indices.
 """
+from functools import wraps
 import ctypes
 
 from cwrap import BaseCClass
@@ -69,7 +70,7 @@ def select_method(select):
        # Select all cells with j[0:5] AND i[0:5]:
        region.select_jslice(0, 5, intersect=True)
     """
-
+    @wraps(select)
     def select_wrapper(self , *args ,  **kwargs):
         intersect = 'intersect' in kwargs and kwargs['intersect']
         if intersect:

--- a/python/ecl/util/util/version.py
+++ b/python/ecl/util/util/version.py
@@ -1,7 +1,9 @@
+from functools import wraps
+
 from ecl import EclPrototype
 
-
 def cmp_method(method):
+    @wraps(method)
     def cmp_wrapper(self, other):
         if not isinstance(other, Version):
             other = Version(other[0], other[1], other[2])


### PR DESCRIPTION
**Issue**
Resolves #650 

**Approach**
Use functools wraps in order to correctly copy f.\_\_name\_\_ and f.\_\_doc\_\_ to the replacing function.  
