### PR TITLE
Compile with -fPIC switch

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -199,7 +199,8 @@ endif ()
 
 set_target_properties(ecl PROPERTIES
                           VERSION ${ECL_VERSION_MAJOR}.${ECL_VERSION_MINOR}
-                          SOVERSION ${ECL_VERSION_MAJOR})
+                          SOVERSION ${ECL_VERSION_MAJOR}
+                          POSITION_INDEPENDENT_CODE ON)
 
 install(TARGETS ecl
         EXPORT  ecl-config


### PR DESCRIPTION
Needed when a shared library `somelib.so` links to `libecl.a` library. 