### PR TITLE
Bugfix: do not include inside extern "C" block.

### DIFF
--- a/lib/include/ert/ecl/ecl_init_file.hpp
+++ b/lib/include/ert/ecl/ecl_init_file.hpp
@@ -19,16 +19,16 @@
 #ifndef ERT_ECL_INIT_FILE_H
 #define ERT_ECL_INIT_FILE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <time.h>
 
 #include <ert/ecl/fortio.h>
 #include <ert/ecl/ecl_kw.hpp>
 #include <ert/ecl/ecl_grid.hpp>
 #include <ert/ecl/ecl_util.hpp>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
   void ecl_init_file_fwrite_header( fortio_type * fortio , const ecl_grid_type * grid , const ecl_kw_type * poro , ert_ecl_unit_enum unit_system, int phases , time_t start_date);
 


### PR DESCRIPTION
Fixes a bug causing compile errors with clang (and warnings on gcc) from ecl_grid.hpp:

```
/usr/local/include/ert/ecl/ecl_grid.hpp:280:19: error: conflicting types for 'ecl_grid_alloc_GRDECL_data'
  ecl_grid_type * ecl_grid_alloc_GRDECL_data(int nx,
                  ^
/usr/local/include/ert/ecl/ecl_grid.hpp:114:19: note: previous declaration is here
  ecl_grid_type * ecl_grid_alloc_GRDECL_data(int , int , int , const float *  , const float *  , const int * , bool apply_mapaxes , con...
                  ^
```

The error is caused by the function in namespace ecl (taking double*) getting declared inside the extern block when included via ecl_init_file.hpp, creating a conflict with the function in the global namespace (taking float*).