### PR TITLE
#663 Fix crash when calling ecl_grid_reset_actnum

### DIFF
--- a/lib/ecl/ecl_coarse_cell.cpp
+++ b/lib/ecl/ecl_coarse_cell.cpp
@@ -290,17 +290,13 @@ const int * ecl_coarse_cell_get_box_ptr( const ecl_coarse_cell_type * coarse_cel
 
 void ecl_coarse_cell_update_index( ecl_coarse_cell_type * coarse_cell , int global_index , int * active_index , int * active_fracture_index , int active_value) {
   if (active_value & CELL_ACTIVE_MATRIX) {
-    if (coarse_cell->active_index == -1) {
-      coarse_cell->active_index = *active_index;
-      (*active_index) += 1;
-    }
+    coarse_cell->active_index = *active_index;
+    (*active_index) += 1;
   }
 
   if (active_value & CELL_ACTIVE_FRACTURE) {
-    if (coarse_cell->active_fracture_index == -1) {
-      coarse_cell->active_fracture_index = *active_fracture_index;
-      (*active_fracture_index) += 1;
-    }
+    coarse_cell->active_fracture_index = *active_fracture_index;
+    (*active_fracture_index) += 1;
   }
 
   int_vector_append( coarse_cell->active_cells , global_index );

--- a/lib/ecl/ecl_coarse_cell.cpp
+++ b/lib/ecl/ecl_coarse_cell.cpp
@@ -290,13 +290,17 @@ const int * ecl_coarse_cell_get_box_ptr( const ecl_coarse_cell_type * coarse_cel
 
 void ecl_coarse_cell_update_index( ecl_coarse_cell_type * coarse_cell , int global_index , int * active_index , int * active_fracture_index , int active_value) {
   if (active_value & CELL_ACTIVE_MATRIX) {
-    coarse_cell->active_index = *active_index;
-    (*active_index) += 1;
+    if (coarse_cell->active_index == -1) {
+      coarse_cell->active_index = *active_index;
+      (*active_index) += 1;
+    }
   }
 
   if (active_value & CELL_ACTIVE_FRACTURE) {
-    coarse_cell->active_fracture_index = *active_fracture_index;
-    (*active_fracture_index) += 1;
+    if (coarse_cell->active_fracture_index == -1) {
+      coarse_cell->active_fracture_index = *active_fracture_index;
+      (*active_fracture_index) += 1;
+    }
   }
 
   int_vector_append( coarse_cell->active_cells , global_index );

--- a/lib/ecl/ecl_coarse_cell.cpp
+++ b/lib/ecl/ecl_coarse_cell.cpp
@@ -287,16 +287,9 @@ const int * ecl_coarse_cell_get_box_ptr( const ecl_coarse_cell_type * coarse_cel
 
 
 /*****************************************************************/
-void ecl_coarse_cell_reset_active_index(ecl_coarse_cell_type * coarse_cell, int active_value) {
-    if (active_value & CELL_ACTIVE_MATRIX)
-    {
-        coarse_cell->active_index = -1;
-    }
-
-    if (active_value & CELL_ACTIVE_FRACTURE)
-    {
-        coarse_cell->active_fracture_index = -1;
-    }
+void ecl_coarse_cell_reset_active_index(ecl_coarse_cell_type * coarse_cell) {
+    coarse_cell->active_index = -1;
+    coarse_cell->active_fracture_index = -1;
 }
 
 void ecl_coarse_cell_update_index( ecl_coarse_cell_type * coarse_cell , int global_index , int * active_index , int * active_fracture_index , int active_value) {

--- a/lib/ecl/ecl_coarse_cell.cpp
+++ b/lib/ecl/ecl_coarse_cell.cpp
@@ -287,6 +287,17 @@ const int * ecl_coarse_cell_get_box_ptr( const ecl_coarse_cell_type * coarse_cel
 
 
 /*****************************************************************/
+void ecl_coarse_cell_reset_active_index(ecl_coarse_cell_type * coarse_cell, int active_value) {
+    if (active_value & CELL_ACTIVE_MATRIX)
+    {
+        coarse_cell->active_index = -1;
+    }
+
+    if (active_value & CELL_ACTIVE_FRACTURE)
+    {
+        coarse_cell->active_fracture_index = -1;
+    }
+}
 
 void ecl_coarse_cell_update_index( ecl_coarse_cell_type * coarse_cell , int global_index , int * active_index , int * active_fracture_index , int active_value) {
   if (active_value & CELL_ACTIVE_MATRIX) {

--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -1871,26 +1871,12 @@ static void ecl_grid_set_active_index(ecl_grid_type * ecl_grid) {
   } else {
     /* --- More involved path in the case of coarsening groups. --- */
 
-    /* 1: Reset cell active_index across the entire grid.
+    /* 1: Reset the coarse cell active_indices.
           In the involved path ecl_coarse_cell_update_index() only updates
           the coarse cells' active_index if it is -1. */
-    for (global_index = 0; global_index < ecl_grid->size; global_index++) {
-        ecl_cell_type * cell = ecl_grid_get_cell(ecl_grid, global_index);
-        if (cell->coarse_group == COARSE_GROUP_NONE)
-        {
-            if (cell->active & CELL_ACTIVE_MATRIX)
-            {
-                cell->active_index[MATRIX_INDEX] = -1;
-            }
-
-            if (cell->active & CELL_ACTIVE_FRACTURE)
-            {
-                cell->active_index[FRACTURE_INDEX] = -1;
-            }
-        } else {
-            ecl_coarse_cell_type * coarse_cell = ecl_grid_iget_coarse_group(ecl_grid, cell->coarse_group);
-            ecl_coarse_cell_reset_active_index(coarse_cell, cell->active);           
-        }
+    for (int coarse_index = 0; coarse_index < vector_get_size(ecl_grid->coarse_cells); coarse_index++) {
+        ecl_coarse_cell_type * coarse_cell = (ecl_coarse_cell_type*)vector_iget_const(ecl_grid->coarse_cells, coarse_index);
+        ecl_coarse_cell_reset_active_index(coarse_cell);
     }
 
     /* 2: Go through all the cells and set the active index. In the

--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -1871,21 +1871,27 @@ static void ecl_grid_set_active_index(ecl_grid_type * ecl_grid) {
   } else {
     /* --- More involved path in the case of coarsening groups. --- */
 
-    /* 1: Reset active_index across the entire grid. The fast path
-          sets active_index no matter what its previous value was.
-          In this path ecl_coarse_cell_update_index() only updates
-          active_index if it is -1. */
+    /* 1: Reset cell active_index across the entire grid.
+          In the involved path ecl_coarse_cell_update_index() only updates
+          the coarse cells' active_index if it is -1. */
     for (global_index = 0; global_index < ecl_grid->size; global_index++) {
         ecl_cell_type * cell = ecl_grid_get_cell(ecl_grid, global_index);
-        if (cell->active & CELL_ACTIVE_MATRIX) {
-            cell->active_index[MATRIX_INDEX] = -1;
-        }
+        if (cell->coarse_group == COARSE_GROUP_NONE)
+        {
+            if (cell->active & CELL_ACTIVE_MATRIX)
+            {
+                cell->active_index[MATRIX_INDEX] = -1;
+            }
 
-        if (cell->active & CELL_ACTIVE_FRACTURE) {
-            cell->active_index[FRACTURE_INDEX] = -1;
+            if (cell->active & CELL_ACTIVE_FRACTURE)
+            {
+                cell->active_index[FRACTURE_INDEX] = -1;
+            }
+        } else {
+            ecl_coarse_cell_type * coarse_cell = ecl_grid_iget_coarse_group(ecl_grid, cell->coarse_group);
+            ecl_coarse_cell_reset_active_index(coarse_cell, cell->active);           
         }
     }
-
 
     /* 2: Go through all the cells and set the active index. In the
           case of coarse cells we only set the common active index of

--- a/lib/ecl/ecl_grid.cpp
+++ b/lib/ecl/ecl_grid.cpp
@@ -1871,7 +1871,23 @@ static void ecl_grid_set_active_index(ecl_grid_type * ecl_grid) {
   } else {
     /* --- More involved path in the case of coarsening groups. --- */
 
-    /* 1: Go through all the cells and set the active index. In the
+    /* 1: Reset active_index across the entire grid. The fast path
+          sets active_index no matter what its previous value was.
+          In this path ecl_coarse_cell_update_index() only updates
+          active_index if it is -1. */
+    for (global_index = 0; global_index < ecl_grid->size; global_index++) {
+        ecl_cell_type * cell = ecl_grid_get_cell(ecl_grid, global_index);
+        if (cell->active & CELL_ACTIVE_MATRIX) {
+            cell->active_index[MATRIX_INDEX] = -1;
+        }
+
+        if (cell->active & CELL_ACTIVE_FRACTURE) {
+            cell->active_index[FRACTURE_INDEX] = -1;
+        }
+    }
+
+
+    /* 2: Go through all the cells and set the active index. In the
           case of coarse cells we only set the common active index of
           the entire coarse cell.
     */
@@ -1903,7 +1919,7 @@ static void ecl_grid_set_active_index(ecl_grid_type * ecl_grid) {
 
 
     /*
-      2: Go through all the coarse cells and set the active index and
+      3: Go through all the coarse cells and set the active index and
          active value of all the cells in the coarse cell to the
          common value for the coarse cell.
     */

--- a/lib/include/ert/ecl/ecl_coarse_cell.hpp
+++ b/lib/include/ert/ecl/ecl_coarse_cell.hpp
@@ -51,6 +51,7 @@ int         ecl_coarse_cell_iget_cell_index(ecl_coarse_cell_type * coarse_cell,
 const int * ecl_coarse_cell_get_index_ptr(ecl_coarse_cell_type * coarse_cell);
 const int_vector_type * ecl_coarse_cell_get_index_vector(ecl_coarse_cell_type * coarse_cell);
 
+void ecl_coarse_cell_reset_active_index(ecl_coarse_cell_type * coarse_cell, int active_value);
 void ecl_coarse_cell_update_index(ecl_coarse_cell_type * coarse_cell,
                                   int global_index,
                                   int * active_index,

--- a/lib/include/ert/ecl/ecl_coarse_cell.hpp
+++ b/lib/include/ert/ecl/ecl_coarse_cell.hpp
@@ -51,7 +51,7 @@ int         ecl_coarse_cell_iget_cell_index(ecl_coarse_cell_type * coarse_cell,
 const int * ecl_coarse_cell_get_index_ptr(ecl_coarse_cell_type * coarse_cell);
 const int_vector_type * ecl_coarse_cell_get_index_vector(ecl_coarse_cell_type * coarse_cell);
 
-void ecl_coarse_cell_reset_active_index(ecl_coarse_cell_type * coarse_cell, int active_value);
+void ecl_coarse_cell_reset_active_index(ecl_coarse_cell_type * coarse_cell);
 void ecl_coarse_cell_update_index(ecl_coarse_cell_type * coarse_cell,
                                   int global_index,
                                   int * active_index,


### PR DESCRIPTION
**Issue**
Resolves #663 

**Approach**
* Following review: reset active_index across the grid for the involved path in ecl_grid_set_active_index.
* It does not appear necessary to do this for the fast path because that sets active_index even if it wasn't -1 before hand.
