### PR TITLE
Remove old cmake flag from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ script:
   - pushd build
   - cmake .. -DBUILD_TESTS=ON
              -DENABLE_PYTHON=ON
-             -DINSTALL_CWRAP=OFF
              -DBUILD_APPLICATIONS=ON
              -DINSTALL_ERT_LEGACY=ON
              -DERT_USE_OPENMP=ON


### PR DESCRIPTION
**Issue**
From the Travis build log:

>
> -- Generating done
> 
> CMake Warning:
>
> Manually-specified variables were not used by the project:
>
>   INSTALL_CWRAP

`INSTALL_CWRAP` is a flag from the old days that is not supported anymore.