### PR TITLE
Don't set util_abort signal handler on py3

### DIFF
--- a/python/ecl/util/util/install_abort_signals.py
+++ b/python/ecl/util/util/install_abort_signals.py
@@ -1,8 +1,10 @@
 from ecl import EclPrototype
+import sys
 import os
 
 def installAbortSignals():
-    if not os.getenv('ECL_SKIP_SIGNAL'):
+    if sys.version_info.major < 3 and not os.getenv('ECL_SKIP_SIGNAL'):
+        install_signals = EclPrototype("void util_install_signals()")
         install_signals()
 
 
@@ -10,9 +12,6 @@ def updateAbortSignals():
     """
     Will install the util_abort_signal for all UNMODIFIED signals.
     """
-    if not os.getenv('ECL_SKIP_SIGNAL'):
+    if sys.version_info.major < 3 and not os.getenv('ECL_SKIP_SIGNAL'):
+        update_signals = EclPrototype("void util_update_signals()")
         update_signals()
-
-
-install_signals = EclPrototype("void util_install_signals()")
-update_signals = EclPrototype("void util_update_signals()")


### PR DESCRIPTION
**Issue**
Resolves #694 

**Approach**
Setting `ECL_SKIP_SIGNAL=1` helps tremendously on getting tests to pass. I've tried to investigate why this error even occurs since the C code seems to be doing the correct thing (although whether libecl should eat all signals is debatable), but I wasn't able to yet.

The """solution""" is to just add a test to the place where libecl checks for `ECL_SKIP_SIGNAL` that also tests that we're on Python 2.7.

But again, no idea if this actually solves the issue yet.