### PR TITLE
Expanded list of rate identifiers

### DIFF
--- a/lib/ecl/tests/ecl_smspec_node.cpp
+++ b/lib/ecl/tests/ecl_smspec_node.cpp
@@ -26,71 +26,165 @@
 
 
 static void test_identify_rate_variable() {
-  const char* rate_vars[] = {
-    "WOPR" , "GGPR" , "FWPR" , "WLPR" , "WOIR" , "FGIR" , "GWIR" ,
-    "WLIR" , "GGOR" , "FWCT" , "SOFR" , "SGFR" , "SWFR" ,
-  };
+/*
+   NOTE: Not all of the following vectors are actual Eclipse vectors,
+   but they are patterns that are supposed to be recognized as (likely) rates.
+*/
+  test_assert_true(smspec_node_identify_rate("ROPR"));
+  test_assert_true(smspec_node_identify_rate("WOIR"));
+  test_assert_true(smspec_node_identify_rate("GOVPR"));
+  test_assert_true(smspec_node_identify_rate("FOVIR"));
+  test_assert_true(smspec_node_identify_rate("COFRL"));
+  test_assert_true(smspec_node_identify_rate("LWOPP"));
+  test_assert_true(smspec_node_identify_rate("LCOPI"));
+  test_assert_true(smspec_node_identify_rate("WOMR"));
 
-  const auto n_var = sizeof(rate_vars) / sizeof(rate_vars[0]);
+  test_assert_true(smspec_node_identify_rate("RGPR"));
+  test_assert_true(smspec_node_identify_rate("WGIR"));
+  test_assert_true(smspec_node_identify_rate("GGVPR"));
+  test_assert_true(smspec_node_identify_rate("FGVIR"));
+  test_assert_true(smspec_node_identify_rate("CGFRL"));
+  test_assert_true(smspec_node_identify_rate("LWGPP"));
+  test_assert_true(smspec_node_identify_rate("LCGPI"));
+  test_assert_true(smspec_node_identify_rate("WGMR"));
+  test_assert_true(smspec_node_identify_rate("GWGPR"));
+  test_assert_true(smspec_node_identify_rate("FWGPR"));
 
-  for (auto var = rate_vars, end = rate_vars + n_var; var != end; ++var)
-    test_assert_true(smspec_node_identify_rate(*var));
+  test_assert_true(smspec_node_identify_rate("RWPR"));
+  test_assert_true(smspec_node_identify_rate("WWIR"));
+  test_assert_true(smspec_node_identify_rate("GWVPR"));
+  test_assert_true(smspec_node_identify_rate("FWVIR"));
+  test_assert_true(smspec_node_identify_rate("CWFRL"));
+  test_assert_true(smspec_node_identify_rate("LWWPP"));
+  test_assert_true(smspec_node_identify_rate("LCWPI"));
+  test_assert_true(smspec_node_identify_rate("WWMR"));
 
-  test_assert_false(smspec_node_identify_rate("SPR"));
-  test_assert_false(smspec_node_identify_rate("SOFT"));
-  test_assert_false(smspec_node_identify_rate("SGFT"));
-  test_assert_false(smspec_node_identify_rate("SWFT"));
+  test_assert_true(smspec_node_identify_rate("RLPR"));
+  test_assert_true(smspec_node_identify_rate("WLFR"));
+  test_assert_true(smspec_node_identify_rate("GVPR"));
+  test_assert_true(smspec_node_identify_rate("FVIR"));
+  test_assert_true(smspec_node_identify_rate("CVFR"));
+
+  test_assert_true(smspec_node_identify_rate("RGLIR"));
+  test_assert_true(smspec_node_identify_rate("WRGR"));
+  test_assert_true(smspec_node_identify_rate("GEGR"));
+  test_assert_true(smspec_node_identify_rate("FEXGR"));
+  test_assert_true(smspec_node_identify_rate("CSGR"));
+  test_assert_true(smspec_node_identify_rate("LWGSR"));
+  test_assert_true(smspec_node_identify_rate("LCFGR"));
+  test_assert_true(smspec_node_identify_rate("WGIMR"));
+  test_assert_true(smspec_node_identify_rate("GGCR"));
+
+  test_assert_true(smspec_node_identify_rate("RNPR"));
+  test_assert_true(smspec_node_identify_rate("WNIR"));
+  test_assert_true(smspec_node_identify_rate("GCPR"));
+  test_assert_true(smspec_node_identify_rate("FCIR"));
+  test_assert_true(smspec_node_identify_rate("CSIR"));
+  test_assert_true(smspec_node_identify_rate("LWSPR"));
+  test_assert_true(smspec_node_identify_rate("LCTIR"));
+  test_assert_true(smspec_node_identify_rate("WTPR"));
+
+  test_assert_true(smspec_node_identify_rate("RGOR"));
+  test_assert_true(smspec_node_identify_rate("WWCT"));
+  test_assert_true(smspec_node_identify_rate("GOGR"));
+  test_assert_true(smspec_node_identify_rate("FWGR"));
+  test_assert_true(smspec_node_identify_rate("CGLRL"));
+
+  test_assert_true(smspec_node_identify_rate("SOFR"));
+  test_assert_true(smspec_node_identify_rate("SGFR"));
+  test_assert_true(smspec_node_identify_rate("SWFR"));
+  test_assert_true(smspec_node_identify_rate("SCFR"));
+  test_assert_true(smspec_node_identify_rate("SSFR"));
+  test_assert_true(smspec_node_identify_rate("STFR"));
+  test_assert_true(smspec_node_identify_rate("SCVPR"));
+  test_assert_true(smspec_node_identify_rate("SWCT"));
+  test_assert_true(smspec_node_identify_rate("SGOR"));
+  test_assert_true(smspec_node_identify_rate("SOGR"));
+  test_assert_true(smspec_node_identify_rate("SWGR"));
+
+  test_assert_true(smspec_node_identify_rate("ROFR"));
+  test_assert_true(smspec_node_identify_rate("RGFR-"));
+  test_assert_true(smspec_node_identify_rate("RNLFR"));
+  test_assert_true(smspec_node_identify_rate("RNLFR+"));
+
+  test_assert_false(smspec_node_identify_rate(""));
+  test_assert_false(smspec_node_identify_rate("HEI"));
+  test_assert_false(smspec_node_identify_rate("GBHP"));
+  test_assert_false(smspec_node_identify_rate("FOPT"));
+  test_assert_false(smspec_node_identify_rate("CWIT"));
+  test_assert_false(smspec_node_identify_rate("LWGPT"));
+  test_assert_false(smspec_node_identify_rate("HELICOPR"));
+  test_assert_false(smspec_node_identify_rate("SOPT"));
+  test_assert_false(smspec_node_identify_rate("RFR"));
+  test_assert_false(smspec_node_identify_rate("ROFT"));
 }
 
 static void test_identify_total_variable() {
-  test_assert_true(smspec_node_identify_total("WOPT", ECL_SMSPEC_WELL_VAR));
-  test_assert_true(smspec_node_identify_total("GGPT", ECL_SMSPEC_GROUP_VAR));
-  test_assert_true(smspec_node_identify_total("FWPT", ECL_SMSPEC_FIELD_VAR));
-  test_assert_true(smspec_node_identify_total("RGIT", ECL_SMSPEC_REGION_VAR));
-  test_assert_true(smspec_node_identify_total("CWIT", ECL_SMSPEC_COMPLETION_VAR));
+/*
+   NOTE: Not all of the following vectors are actual Eclipse vectors,
+   but they are patterns that are supposed to be recognized as (likely) totals.
+*/
+  test_assert_true(smspec_node_identify_total("ROPT", ECL_SMSPEC_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("WOIT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GOVPT", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FOVIT", ECL_SMSPEC_FIELD_VAR));
+  test_assert_true(smspec_node_identify_total("COMT", ECL_SMSPEC_COMPLETION_VAR));
 
-  test_assert_true(smspec_node_identify_total("WOPTF", ECL_SMSPEC_WELL_VAR));
-  test_assert_true(smspec_node_identify_total("GOPTS", ECL_SMSPEC_GROUP_VAR));
-  test_assert_true(smspec_node_identify_total("FOIT", ECL_SMSPEC_FIELD_VAR));
-  test_assert_true(smspec_node_identify_total("ROVPT", ECL_SMSPEC_REGION_VAR));
-  test_assert_true(smspec_node_identify_total("COVIT", ECL_SMSPEC_COMPLETION_VAR));
+  test_assert_true(smspec_node_identify_total("RGPT", ECL_SMSPEC_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("WGIT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GGVPT", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FGVIT", ECL_SMSPEC_FIELD_VAR));
+  test_assert_true(smspec_node_identify_total("WGMT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GWGPT", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FWGPT", ECL_SMSPEC_FIELD_VAR));
 
-  test_assert_true(smspec_node_identify_total("WMWT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("RWPT", ECL_SMSPEC_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("WWIT", ECL_SMSPEC_WELL_VAR));
   test_assert_true(smspec_node_identify_total("GWVPT", ECL_SMSPEC_GROUP_VAR));
   test_assert_true(smspec_node_identify_total("FWVIT", ECL_SMSPEC_FIELD_VAR));
-  test_assert_true(smspec_node_identify_total("RGMT", ECL_SMSPEC_REGION_VAR));
-  test_assert_true(smspec_node_identify_total("CGPTF", ECL_SMSPEC_COMPLETION_VAR));
+  test_assert_true(smspec_node_identify_total("WWMT", ECL_SMSPEC_WELL_VAR));
 
-  test_assert_true(smspec_node_identify_total("WSGT", ECL_SMSPEC_WELL_VAR));
-  test_assert_true(smspec_node_identify_total("GGST", ECL_SMSPEC_GROUP_VAR));
-  test_assert_true(smspec_node_identify_total("FFGT", ECL_SMSPEC_FIELD_VAR));
-  test_assert_true(smspec_node_identify_total("RGCT", ECL_SMSPEC_REGION_VAR));
-  test_assert_true(smspec_node_identify_total("CGIMT", ECL_SMSPEC_COMPLETION_VAR));
+  test_assert_true(smspec_node_identify_total("RLPT", ECL_SMSPEC_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("GVPT", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FVIT", ECL_SMSPEC_FIELD_VAR));
 
-  test_assert_true(smspec_node_identify_total("WWGPT", ECL_SMSPEC_WELL_VAR));
-  test_assert_true(smspec_node_identify_total("GWGIT", ECL_SMSPEC_GROUP_VAR));
-  test_assert_true(smspec_node_identify_total("FEGT", ECL_SMSPEC_FIELD_VAR));
-  test_assert_true(smspec_node_identify_total("REXGT", ECL_SMSPEC_REGION_VAR));
-  test_assert_true(smspec_node_identify_total("CGVPT", ECL_SMSPEC_COMPLETION_VAR));
+  test_assert_true(smspec_node_identify_total("WRGT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GEGT", ECL_SMSPEC_GROUP_VAR));
+  test_assert_true(smspec_node_identify_total("FEXGT", ECL_SMSPEC_FIELD_VAR));
+  test_assert_true(smspec_node_identify_total("CSGT", ECL_SMSPEC_COMPLETION_VAR));
+  test_assert_true(smspec_node_identify_total("LWGST", ECL_SMSPEC_LOCAL_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("LCFGT", ECL_SMSPEC_LOCAL_COMPLETION_VAR));
+  test_assert_true(smspec_node_identify_total("WGIMT", ECL_SMSPEC_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("GGCT", ECL_SMSPEC_GROUP_VAR));
 
-  test_assert_true(smspec_node_identify_total("WGVIT", ECL_SMSPEC_WELL_VAR));
-  test_assert_true(smspec_node_identify_total("GLPT", ECL_SMSPEC_GROUP_VAR));
-  test_assert_true(smspec_node_identify_total("FVPT", ECL_SMSPEC_FIELD_VAR));
-  test_assert_true(smspec_node_identify_total("RVIT", ECL_SMSPEC_REGION_VAR));
-  test_assert_true(smspec_node_identify_total("CNPT", ECL_SMSPEC_COMPLETION_VAR));
-
+  test_assert_true(smspec_node_identify_total("RNPT", ECL_SMSPEC_REGION_VAR));
   test_assert_true(smspec_node_identify_total("WNIT", ECL_SMSPEC_WELL_VAR));
   test_assert_true(smspec_node_identify_total("GCPT", ECL_SMSPEC_GROUP_VAR));
   test_assert_true(smspec_node_identify_total("FCIT", ECL_SMSPEC_FIELD_VAR));
+  test_assert_true(smspec_node_identify_total("CSIT", ECL_SMSPEC_COMPLETION_VAR));
+  test_assert_true(smspec_node_identify_total("LWSPT", ECL_SMSPEC_LOCAL_WELL_VAR));
+  test_assert_true(smspec_node_identify_total("LCTIT", ECL_SMSPEC_LOCAL_COMPLETION_VAR));
+  test_assert_true(smspec_node_identify_total("WTPT", ECL_SMSPEC_WELL_VAR));
 
   test_assert_true(smspec_node_identify_total("SOFT", ECL_SMSPEC_SEGMENT_VAR));
   test_assert_true(smspec_node_identify_total("SGFT", ECL_SMSPEC_SEGMENT_VAR));
   test_assert_true(smspec_node_identify_total("SWFT", ECL_SMSPEC_SEGMENT_VAR));
 
-  test_assert_false(smspec_node_identify_total("SOPT", ECL_SMSPEC_SEGMENT_VAR));
-  test_assert_false(smspec_node_identify_total("HEI!", ECL_SMSPEC_SEGMENT_VAR));
-  test_assert_false(smspec_node_identify_total("xXx", ECL_SMSPEC_SEGMENT_VAR));
-  test_assert_false(smspec_node_identify_total("SPR", ECL_SMSPEC_SEGMENT_VAR));
+  test_assert_true(smspec_node_identify_total("RGFT", ECL_SMSPEC_REGION_2_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("RWFT-", ECL_SMSPEC_REGION_2_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("RNLFT", ECL_SMSPEC_REGION_2_REGION_VAR));
+  test_assert_true(smspec_node_identify_total("RNLFT+", ECL_SMSPEC_REGION_2_REGION_VAR));
+
+  test_assert_false(smspec_node_identify_total("", ECL_SMSPEC_REGION_VAR));
+  test_assert_false(smspec_node_identify_total("HEI", ECL_SMSPEC_WELL_VAR));
+  test_assert_false(smspec_node_identify_total("GBHP", ECL_SMSPEC_GROUP_VAR));
+  test_assert_false(smspec_node_identify_total("FOPR", ECL_SMSPEC_FIELD_VAR));
+  test_assert_false(smspec_node_identify_total("CWIR", ECL_SMSPEC_COMPLETION_VAR));
+  test_assert_false(smspec_node_identify_total("LWGPR", ECL_SMSPEC_LOCAL_WELL_VAR));
+  test_assert_false(smspec_node_identify_total("CWCT", ECL_SMSPEC_LOCAL_COMPLETION_VAR));
+  test_assert_false(smspec_node_identify_total("SGPT", ECL_SMSPEC_SEGMENT_VAR));
+  test_assert_false(smspec_node_identify_total("RFT", ECL_SMSPEC_REGION_2_REGION_VAR));
+  test_assert_false(smspec_node_identify_total("ROFR", ECL_SMSPEC_REGION_2_REGION_VAR));
 }
 
 


### PR DESCRIPTION
**Issue**
Resolves #706 

**Approach**
Added several additional rate identifiers in addition to remaining production ratios (addition to already existing water-cut (WCT) and gas-oil ratio (GOR). Structured them into groups per line with a small comment section to make it a bit more human friendly to read. Also wanted to include some var_type verification similar to what is done in [smspec_node_identify_total](https://github.com/equinor/libecl/blob/6f89be14d0c8c62c606d2da17c580115cfce3b75/lib/ecl/smspec_node.cpp#L461-L509), but the additional required input parameter broke (at least) the python API and I couldn't (fairly quickly) identify why. Limited experience with C++, so I'll blame that 😉  Also not really sure if that var_type logic provides a lot of extra benefits. If someone wants to add it (or help me on the way), feel free.

I didn't add absolutely all rate vectors in the manual, but (most of) the relevant ones should hopefully be in. At least a lot more than there has been previously.
Might be an idea to take a similar look at the `smspec_node_identify_total` if you find this ok, though that list seems more comprehensive already.  (did add a couple on is_total, but just some that I came across when looking at rates) 
