### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# These owners will be the default owners for everything in the repo.
-*       @markusdregi @lars-petter-hauge @andreabrambilla @pgdr @jokva @xjules


### PR DESCRIPTION
Remove CODEOWNERS -- our current workflow involves using the web UI to manage Github access, so this file is superfluous.
