### PR TITLE
Rename CMake project from ert -> ecl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required( VERSION 2.8.12 ) # If you are creating Python wrappers for Windows, the actual version requirement is 3.4
-project( ERT C CXX )
+project( ecl C CXX )
 
 include(GNUInstallDirs)
 include(TestBigEndian)


### PR DESCRIPTION
The title bar of my IDE showed **ERT** instead of **ecl**, so to reduce the confusion I experienced while navigating between the different open projects, I propose to change the project name in the CMake file. This PR implements this proposal.