### PR TITLE
Rename libecl to ecl

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: Libecl testing
+name: ecl testing
 
 on: [push, pull_request]
 
@@ -19,7 +19,7 @@ jobs:
         # required for `git describe --tags` to work
         fetch-depth: 0
 
-    - name: Build libecl
+    - name: Build ecl
       run: |
         mkdir cmake-build
         cmake -S . -B cmake-build -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -47,6 +47,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        # required for `git describe --tags` to work
+        fetch-depth: 0
 
     - name: Build Linux Wheel
       uses: docker://quay.io/pypa/manylinux2010_x86_64
@@ -70,7 +73,20 @@ jobs:
         name: ${{ matrix.os }} Python ${{ matrix.python }} wheel
         path: dist/*
 
-    - name: Install libecl
+    - name: Build `libecl` migration package
+      run: |
+        pip install -U pip setuptools wheel setuptools_scm
+        python ci/github/setup.py bdist_wheel --dist-dir=dist-migration
+      if: matrix.os == 'ubuntu-latest' && matrix.python == '3.6'
+
+    - name: Upload `libecl` migration wheel as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Python libecl to ecl wheel
+        path: dist-migration/*
+      if: matrix.os == 'ubuntu-latest' && matrix.python == '3.6'
+
+    - name: Install ecl
       run: pip install dist/*
 
     - name: Run Python tests

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ __ecl_lib_info.py
 /python/ecl/version.py
 .*
 *.egg-info/
+
+/dist
+/dist-*

--- a/README.md
+++ b/README.md
@@ -1,68 +1,68 @@
-# libecl [![Build Status](https://travis-ci.org/Equinor/libecl.svg?branch=master)](https://travis-ci.org/Equinor/libecl)
+# ecl [![Build Status](https://github.com/equinor/libecl/workflows/ecl%20testing/badge.svg)](https://github.com/equinor/libecl/actions)
 
 
-*libecl* is a package for reading and writing the result files from
+*ecl* is a package for reading and writing the result files from
 the Eclipse reservoir simulator. The file types covered are the
 restart, init, rft, summary and grid files. Both unified and
 non-unified and formatted and unformatted files are supported.
 
-*libecl* is mainly developed on *Linux* and *macOS*, in addition there
+*ecl* is mainly developed on *Linux* and *macOS*, in addition there
 is a portability layer which ensures that most of the functionality is
 available on *Windows*. The main functionality is written in C/C++, and
-should typically be linked in in other compiled programs. *libecl* was
+should typically be linked in in other compiled programs. *ecl* was
 initially developed as part of the [Ensemble Reservoir
 Tool](http://github.com/Equinor/ert), other applications using
-*libecl* are the reservoir simulator flow and Resinsight from the [OPM
+*ecl* are the reservoir simulator flow and Resinsight from the [OPM
 project](http://github.com/OPM/).
 
 ### Alternative 1: Python only ###
 For small interactive scripts, such as forward models, the recommended way to
-use *libecl* is by installing it from PyPI. This method doesn't require setting
+use *ecl* is by installing it from PyPI. This method doesn't require setting
 `PYTHONPATH` or `LD_LIBRARY_PATH` environment variables:
 
 ```
-$ pip install libecl
+$ pip install ecl
 ```
 
 ### Alternative 2: C library only ###
-This is for when you need to link directly with the *libecl* C library, but
-don't need the Python bindings. *libecl* requires a conforming C++11 or later
+This is for when you need to link directly with the *ecl* C library, but
+don't need the Python bindings. *ecl* requires a conforming C++11 or later
 compiler such as GNU GCC, the CMake build system and, optionally, zlib.
 
 ```bash
-$ git clone https://github.com/Equinor/libecl
-$ mkdir libecl/build
-$ cd libecl/build
+$ git clone https://github.com/Equinor/ecl
+$ mkdir ecl/build
+$ cd ecl/build
 $ cmake ..
 $ make
 $ make install
 ```
 
-To install *libecl* in a non-standard location, add
+To install *ecl* in a non-standard location, add
 `-DCMAKE_INSTALL_PREFIX=/path/to/install` to the first `cmake` command. Remember
 to set `LD_LIBRARY_PATH=/path/to/install/lib64:$LD_LIBRARY_PATH` if you do use a
 non-standard location for your program to find `libecl.so`.
 
-If you intend to develop and change *libecl* you should build the tests by
+If you intend to develop and change *ecl* you should build the tests by
 passing `-DBUILD_TESTS=ON` and run the tests with `ctest`.
 
 ### Alternative 3: C library with Python bindings ###
 It is also possible to install both the C library and Python bindings using
-CMake. Note that this alternative is incompatible with *libecl* installed from
+CMake. Note that this alternative is incompatible with *ecl* installed from
 PyPI (_Alternative 1_). As before, we require a conforming C++11 or later
 compiler, CMake and, optionally, zlib.
 
 ```bash
-$ git clone https://github.com/Equinor/libecl
-$ mkdir libecl/build
-$ cd libecl/build
+$ git clone https://github.com/Equinor/ecl
+$ mkdir ecl/build
+$ cd ecl/build
 $ pip install -r ../requirements.txt
 $ cmake .. -DENABLE_PYTHON=ON
 $ make
 $ make install
 ```
 
-You will most likely want to install *libecl* into a Python virtual environment.
+You will most likely want to install *ecl* into a Python virtual environment.
 First activate the virtualenv, then add the argument
 `-DCMAKE_INSTALL_PREFIX=$(python -c "import sys; print(sys.prefix)")` to the
 `cmake` command when building.

--- a/ci/github/setup.py
+++ b/ci/github/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup
+from setuptools_scm import get_version
+
+
+version = get_version()
+
+
+setup(
+    name="libecl",
+    author="Equinor ASA",
+    author_email="fg_sib-scout@equinor.com",
+    version=version,
+    install_requires=["ecl==" + version],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import skbuild
 import setuptools
@@ -8,16 +6,19 @@ from setuptools_scm import get_version
 
 version = get_version(relative_to=__file__, write_to="python/ecl/version.py")
 
+
 with open("README.md") as f:
     long_description = f.read()
 
+
 skbuild.setup(
-    name="libecl",
+    name="ecl",
     author="Equinor ASA",
+    author_email="fg_sib-scout@equinor.com",
     description="Package for reading and writing the result files from the ECLIPSE reservoir simulator",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/equinor/libecl",
+    url="https://github.com/equinor/ecl",
     packages=setuptools.find_packages(where='python', exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_dir={"": "python"},
     license="GPL-3.0",


### PR DESCRIPTION
Resolves: #710

Also add `libecl` package that installs `ecl` of the same version

---

To test libecl -> ecl:
1. Go to https://github.com/equinor/libecl/pull/744/checks
2. Click on the artifacts
3. Download `libecl -> ecl` zip
4. Download the zip for your version of Python
5. Unzip both
6. `pip install ./libecl-*.whl -f .`

Both `ecl` and `libecl` should now be installed.

When this is uploaded to PyPI it will suffice to write `pip install libecl` to get the correct `ecl`.